### PR TITLE
fix: catch SIGINT/SIGTERM in dangerous commands instead of dying

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,45 @@ mod ramdisk;
 mod state;
 mod volume;
 
+use std::process;
+
+use tokio::signal::unix::{SignalKind, signal};
+
 use cli::{Cli, Command};
+
+/// Install signal handlers that ignore SIGINT and SIGTERM, printing a warning instead.
+///
+/// Commands like `recover`, `mount`, `promote`, and `full-recover` manipulate dm-era devices
+/// and block volumes in multi-step sequences. Interrupting them mid-way can leave volumes in
+/// an inconsistent state that requires a costly full recovery. We catch these signals and
+/// refuse to act on them, letting the operation complete naturally.
+fn ignore_termination_signals() {
+    // Register signal handlers synchronously so they take effect immediately,
+    // before the spawned task is polled. This avoids a race where a signal
+    // arrives before the async block starts executing.
+    let mut sigint = signal(SignalKind::interrupt()).unwrap();
+    let mut sigterm = signal(SignalKind::terminate()).unwrap();
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = sigint.recv() => {
+                    eprintln!(
+                        "\nRefusing to handle signal. Interrupting this operation can corrupt your volumes.\n\
+                         If you really want to stop it, use: kill -9 {}",
+                        process::id()
+                    );
+                }
+                _ = sigterm.recv() => {
+                    eprintln!(
+                        "\nRefusing to handle signal. Interrupting this operation can corrupt your volumes.\n\
+                         If you really want to stop it, use: kill -9 {}",
+                        process::id()
+                    );
+                }
+            }
+        }
+    });
+}
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
@@ -51,10 +89,22 @@ async fn main() -> eyre::Result<()> {
             )
             .await
         }
-        Some(Command::FullRecover) => commands::full_recover::run(cli.yes).await,
-        Some(Command::Mount) => commands::mount::run().await,
-        Some(Command::Recover { kill }) => commands::recover::run(kill).await,
-        Some(Command::Promote { kill }) => commands::promote::run(cli.yes, kill).await,
+        Some(Command::FullRecover) => {
+            ignore_termination_signals();
+            commands::full_recover::run(cli.yes).await
+        }
+        Some(Command::Mount) => {
+            ignore_termination_signals();
+            commands::mount::run().await
+        }
+        Some(Command::Recover { kill }) => {
+            ignore_termination_signals();
+            commands::recover::run(kill).await
+        }
+        Some(Command::Promote { kill }) => {
+            ignore_termination_signals();
+            commands::promote::run(cli.yes, kill).await
+        }
         Some(Command::Status) | None => commands::status::run().await,
     }
 }


### PR DESCRIPTION
## Summary
Catch `^C` (SIGINT) and SIGTERM during `recover`, `mount`, `promote`, and `full-recover` — print a warning and keep going instead of dying mid-operation.

## Motivation
Interrupting these commands mid-way can leave dm-era devices and volumes in an inconsistent state requiring a costly full recovery.

## Changes
- Added `ignore_termination_signals()` in `main.rs` that spawns a tokio task catching SIGINT/SIGTERM
- On signal, prints a message refusing to handle it and suggests `kill -9 <pid>` as the escape hatch
- Installed before dispatching to `recover`, `mount`, `promote`, and `full-recover`
- `init` and `status` are unaffected (safe to interrupt)

## Testing
`cargo build` + `cargo fmt --check` pass. Pre-existing clippy warnings in other files unchanged.

Prompted by: pep