### PR TITLE
fix: add destructive warning to promote command help text

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,7 +72,7 @@ pub enum Command {
         kill: bool,
     },
 
-    /// ⚠️  DESTRUCTIVE: Overwrite virgin volume with current scratch state.
+    /// DESTRUCTIVE: Overwrite virgin volume with current scratch state.
     ///
     /// Permanently replaces the virgin (golden image) with the current scratch
     /// contents. The old virgin data is lost and cannot be recovered.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,7 +72,7 @@ pub enum Command {
         kill: bool,
     },
 
-    /// DESTRUCTIVE: Overwrite virgin volume with current scratch state.
+    /// Overwrite virgin volume with current scratch state (destructive).
     ///
     /// Permanently replaces the virgin (golden image) with the current scratch
     /// contents. The old virgin data is lost and cannot be recovered.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,7 +72,11 @@ pub enum Command {
         kill: bool,
     },
 
-    /// Promote scratch state to virgin (update baseline)
+    /// ⚠️  DESTRUCTIVE: Overwrite virgin volume with current scratch state.
+    ///
+    /// Permanently replaces the virgin (golden image) with the current scratch
+    /// contents. The old virgin data is lost and cannot be recovered.
+    /// Only use this when the scratch state should become the new baseline.
     Promote {
         /// Kill processes blocking unmount instead of failing
         #[arg(short = 'k', long = "kill")]

--- a/src/commands/promote.rs
+++ b/src/commands/promote.rs
@@ -59,7 +59,7 @@ pub async fn run(yes: bool, kill: bool) -> Result<()> {
         ));
     }
 
-    println!("DESTRUCTIVE: Promoting scratch to virgin");
+    println!("Promoting scratch to virgin (destructive)");
     println!("  Virgin:  {}", app_state.virgin.display());
     println!("  Scratch: {}", app_state.scratch.display());
     println!();

--- a/src/commands/promote.rs
+++ b/src/commands/promote.rs
@@ -59,13 +59,14 @@ pub async fn run(yes: bool, kill: bool) -> Result<()> {
         ));
     }
 
-    println!("Promoting scratch to virgin (updating baseline)");
+    println!("⚠️  DESTRUCTIVE: Promoting scratch to virgin");
     println!("  Virgin:  {}", app_state.virgin.display());
     println!("  Scratch: {}", app_state.scratch.display());
     println!();
-    println!("WARNING: This will permanently modify the virgin volume.");
+    println!("WARNING: This will permanently overwrite the virgin volume with scratch.");
+    println!("         The old virgin data will be LOST and cannot be recovered.");
 
-    confirm::require("Proceed with promote?", yes)?;
+    confirm::require("Permanently overwrite virgin volume?", yes)?;
 
     println!();
 

--- a/src/commands/promote.rs
+++ b/src/commands/promote.rs
@@ -59,7 +59,7 @@ pub async fn run(yes: bool, kill: bool) -> Result<()> {
         ));
     }
 
-    println!("⚠️  DESTRUCTIVE: Promoting scratch to virgin");
+    println!("DESTRUCTIVE: Promoting scratch to virgin");
     println!("  Virgin:  {}", app_state.virgin.display());
     println!("  Scratch: {}", app_state.scratch.display());
     println!();


### PR DESCRIPTION
## Problem

The `promote` command permanently overwrites the virgin volume with the current scratch state, but the previous help text (`Promote scratch state to virgin (update baseline)`) was too ambiguous. This led to [accidental data loss](https://ampcode.com/threads/T-019c9996-5b67-733f-bdb7-57a067a13186) when the command was misinterpreted as "save a checkpoint" rather than "permanently overwrite the only clean baseline."

## Changes

- **`--help` text**: Changed from `Promote scratch state to virgin (update baseline)` to `⚠️ DESTRUCTIVE: Overwrite virgin volume with current scratch state` with a long description explaining the operation is irreversible
- **Runtime warning**: Now explicitly states the old virgin data will be LOST and cannot be recovered
- **Confirmation prompt**: Changed from `Proceed with promote?` to `Permanently overwrite virgin volume?` to make the gravity of the action clear