### PR TITLE
fix: add init validation guardrails and fix clippy warnings

### DIFF
--- a/src/commands/init_common.rs
+++ b/src/commands/init_common.rs
@@ -1,0 +1,79 @@
+// Common validation for init-new and init-from commands.
+
+use std::path::Path;
+
+use eyre::{Result, eyre};
+
+/// Validate granularity is sane for dm-era.
+pub fn validate_granularity(granularity: u64) -> Result<()> {
+    if granularity == 0 {
+        return Err(eyre!("Granularity must be greater than 0."));
+    }
+    if !granularity.is_multiple_of(512) {
+        return Err(eyre!(
+            "Granularity must be a multiple of 512 bytes (got {} bytes).",
+            granularity
+        ));
+    }
+    Ok(())
+}
+
+/// Reject configurations where virgin and scratch point to the same device.
+pub fn reject_same_device(virgin: &Path, scratch: &Path) -> Result<()> {
+    let v = std::fs::canonicalize(virgin).unwrap_or_else(|_| virgin.to_path_buf());
+    let s = std::fs::canonicalize(scratch).unwrap_or_else(|_| scratch.to_path_buf());
+
+    if v == s {
+        return Err(eyre!(
+            "Virgin and scratch must be different devices.\n  \
+             Virgin:  {}\n  \
+             Scratch: {}",
+            virgin.display(),
+            scratch.display()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+
+    #[test]
+    fn granularity_zero_rejected() {
+        assert!(validate_granularity(0).is_err());
+    }
+
+    #[test]
+    fn granularity_not_512_multiple_rejected() {
+        assert!(validate_granularity(4097).is_err());
+        assert!(validate_granularity(1000).is_err());
+    }
+
+    #[test]
+    fn granularity_valid_accepted() {
+        assert!(validate_granularity(512).is_ok());
+        assert!(validate_granularity(4096).is_ok());
+    }
+
+    #[test]
+    fn same_device_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vol.img");
+        File::create(&path).unwrap();
+
+        assert!(reject_same_device(&path, &path).is_err());
+    }
+
+    #[test]
+    fn different_devices_accepted() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.img");
+        let b = dir.path().join("b.img");
+        File::create(&a).unwrap();
+        File::create(&b).unwrap();
+
+        assert!(reject_same_device(&a, &b).is_ok());
+    }
+}

--- a/src/commands/init_from.rs
+++ b/src/commands/init_from.rs
@@ -38,6 +38,9 @@ pub async fn run(
 ) -> Result<()> {
     env::require_root()?;
 
+    super::init_common::validate_granularity(granularity)?;
+    super::init_common::reject_same_device(&virgin, &scratch)?;
+
     // Check if already initialized.
     if let Some(existing) = state::load()? {
         confirm::require(

--- a/src/commands/init_new.rs
+++ b/src/commands/init_new.rs
@@ -31,6 +31,9 @@ pub async fn run(
 ) -> Result<()> {
     env::require_root()?;
 
+    super::init_common::validate_granularity(granularity)?;
+    super::init_common::reject_same_device(&virgin, &scratch)?;
+
     // Check that mkfs.ext4 is available before doing anything else
     volume::check_mkfs_ext4().await?;
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 // Command module - re-exports all command handlers
 
 pub mod full_recover;
+mod init_common;
 pub mod init_from;
 pub mod init_new;
 pub mod mount;

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -24,7 +24,9 @@ pub async fn run() -> Result<()> {
         None => {
             println!("schelk is not initialized.");
             println!();
-            println!("Run 'schelk init' to configure schelk with your volumes.");
+            println!(
+                "Run 'schelk init-new' or 'schelk init-from' to configure schelk with your volumes."
+            );
         }
         Some(state) => {
             println!("schelk status");

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ pub use eyre::eyre;
 // Helper functions to create common errors with consistent messages
 
 pub fn not_initialized() -> eyre::Report {
-    eyre!("schelk has not been initialized. Run 'schelk init' first.")
+    eyre!("schelk has not been initialized. Run 'schelk init-new' or 'schelk init-from' first.")
 }
 
 pub fn volume_mismatch() -> eyre::Report {


### PR DESCRIPTION
## Summary

Validation guardrails for init-new and init-from commands.

- Validate granularity (reject 0, require 512-byte multiple)
- Reject same-device configs for virgin/scratch (resolve symlinks)
- Fix stale 'schelk init' references in error.rs and status.rs

## Testing

5 new tests + all existing tests pass. `cargo test`, `cargo clippy`, `cargo fmt` all clean.

Co-Authored-By: Sergei Shulepov <2205845+pepyakin@users.noreply.github.com>

Prompted by: pep