### PR TITLE
Fail fast on non-Linux builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "schelk"
 version = "0.1.0"
 edition = "2024"
+build = "build.rs"
 authors = ["Sergei Shulepov <pep@tempo.xyz>"]
 repository = "https://github.com/tempoxyz/schelk"
 description = "Fast snapshot rollback tool using dm-era for database bench"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,15 @@
-#[cfg(not(target_os = "linux"))]
-compile_error!("schelk is Linux-only and is not supposed to be compiled on this platform");
+fn main() {
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS");
+    println!("cargo:rerun-if-env-changed=TARGET");
 
-fn main() {}
+    let target_os =
+        std::env::var("CARGO_CFG_TARGET_OS").expect("Cargo did not set CARGO_CFG_TARGET_OS");
+
+    if target_os != "linux" {
+        let target = std::env::var("TARGET").unwrap_or_else(|_| "<unknown>".to_string());
+        panic!(
+            "schelk only supports Linux targets; requested target `{}` (target_os=`{}`)",
+            target, target_os
+        );
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+#[cfg(not(target_os = "linux"))]
+compile_error!("schelk is Linux-only and is not supposed to be compiled on this platform");
+
+fn main() {}


### PR DESCRIPTION
## Summary
- add a minimal `build.rs` target guard for Linux-only support
- wire build script in `Cargo.toml`
- fail early with a clear compile error on macOS/non-Linux instead of later Linux-API errors

## Validation
- Ran `cargo build` on macOS
- Confirmed it now fails immediately with:
  - `schelk is Linux-only and is not supposed to be compiled on this platform`
