### PR TITLE
fix: log auto-confirmed actions when using -y

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -18,6 +18,9 @@ There are many errors modes in this tool. We need to defend against that. The us
 6. mount should check whether there is already mount.
 7. By default the commands are interactive and destructive operations must be confirmed either via
    the CLI flag -y or a press.
+8. `-y` means "skip the interactive prompt" — it does NOT mean "silently swallow everything". When
+   `-y` auto-confirms a destructive action, the tool must still log what it is doing. The user 
+   should always be able to see from the output what decisions were made on their behalf.
 
 ## Commands
 

--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -20,10 +20,11 @@ pub fn prompt(message: &str) -> Result<bool> {
 }
 
 /// Require user confirmation for a destructive operation
-/// If skip is true (from -y flag), returns Ok immediately
+/// If skip is true (from -y flag), logs the auto-confirmed action and returns Ok
 /// Otherwise prompts the user and returns error if they decline
 pub fn require(message: &str, skip: bool) -> Result<()> {
     if skip {
+        println!("[auto-confirmed] {}", message);
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary

`-y` now prints `[auto-confirmed] <message>` for each skipped confirmation instead of silently proceeding. The user always sees what decisions were made on their behalf.

## Changes

- `confirm::require()` logs the confirmation message when `-y` auto-skips
- SPEC.md mindset updated: `-y` means skip the prompt, not hide the action

## Testing

All 16 tests pass.

Co-Authored-By: Sergei Shulepov <2205845+pepyakin@users.noreply.github.com>

Prompted by: pep