### PR TITLE
feat: separate --reinit flag from -y for distinct confirmation decisions

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -17,7 +17,21 @@ There are many errors modes in this tool. We need to defend against that. The us
 5. the app should prepare for crash of the system or the app itself.
 6. mount should check whether there is already mount.
 7. By default the commands are interactive and destructive operations must be confirmed either via
-   the CLI flag -y or a press.
+   a CLI flag or an interactive prompt.
+
+### Confirmation Semantics
+
+The `-y` (or `--yes`) flag means "skip the primary destructive-action prompt". It does **not**
+silently approve unrelated decisions. When a command requires multiple distinct approvals (e.g.,
+"Reinitialize existing state?" and "Proceed with destruction?"), each approval has its own flag:
+
+| Approval            | Flag        | Purpose                                         |
+|---------------------|-------------|--------------------------------------------------|
+| Reinitialize state  | `--reinit`  | Approve overwriting existing schelk app state.   |
+| Destructive proceed | `-y`        | Skip the primary "are you sure?" prompt.         |
+
+When a flag auto-skips a prompt, the tool prints `[auto-confirmed] <message>` so the user
+can see what was approved on their behalf in logs and CI output.
 
 ## Commands
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,6 +53,10 @@ pub enum Command {
         /// Block granularity in bytes
         #[arg(long, default_value = "4096")]
         granularity: u64,
+
+        /// Allow reinitializing over existing app state without prompting
+        #[arg(long)]
+        reinit: bool,
     },
 
     /// Adopt an existing pre-populated virgin volume (destructive to scratch)
@@ -89,6 +93,10 @@ pub enum Command {
         /// Skip copying virgin to scratch
         #[arg(long)]
         no_copy: bool,
+
+        /// Allow reinitializing over existing app state without prompting
+        #[arg(long)]
+        reinit: bool,
     },
 
     /// Copy virgin volume to scratch volume (full restore)

--- a/src/commands/init_from.rs
+++ b/src/commands/init_from.rs
@@ -24,7 +24,7 @@ use crate::state::{self, AppState};
 use crate::volume;
 
 /// Run the init-from command
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub async fn run(
     virgin: PathBuf,
     scratch: PathBuf,
@@ -35,6 +35,7 @@ pub async fn run(
     granularity: u64,
     no_copy: bool,
     yes: bool,
+    reinit: bool,
 ) -> Result<()> {
     env::require_root()?;
 
@@ -54,7 +55,7 @@ pub async fn run(
                 existing.virgin.display(),
                 existing.scratch.display()
             ),
-            yes,
+            reinit,
         )?;
     }
 

--- a/src/commands/init_new.rs
+++ b/src/commands/init_new.rs
@@ -20,6 +20,7 @@ use crate::state::{self, AppState};
 use crate::volume;
 
 /// Run the init-new command
+#[expect(clippy::too_many_arguments)]
 pub async fn run(
     virgin: PathBuf,
     scratch: PathBuf,
@@ -28,6 +29,7 @@ pub async fn run(
     mount_options: Option<String>,
     granularity: u64,
     yes: bool,
+    reinit: bool,
 ) -> Result<()> {
     env::require_root()?;
 
@@ -50,7 +52,7 @@ pub async fn run(
                 existing.virgin.display(),
                 existing.scratch.display()
             ),
-            yes,
+            reinit,
         )?;
     }
 

--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -19,11 +19,14 @@ pub fn prompt(message: &str) -> Result<bool> {
     Ok(response == "y" || response == "yes")
 }
 
-/// Require user confirmation for a destructive operation
-/// If skip is true (from -y flag), returns Ok immediately
-/// Otherwise prompts the user and returns error if they decline
+/// Require user confirmation for a destructive operation.
+///
+/// If `skip` is true (from a CLI flag), prints `[auto-confirmed]` and returns
+/// `Ok` without prompting. Otherwise prompts interactively and returns an error
+/// if the user declines.
 pub fn require(message: &str, skip: bool) -> Result<()> {
     if skip {
+        println!("[auto-confirmed] {}", message);
         return Ok(());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,7 @@ async fn main() -> eyre::Result<()> {
             mount_point,
             mount_options,
             granularity,
+            reinit,
         }) => {
             commands::init_new::run(
                 virgin,
@@ -84,6 +85,7 @@ async fn main() -> eyre::Result<()> {
                 mount_options,
                 granularity,
                 cli.yes,
+                reinit,
             )
             .await
         }
@@ -96,6 +98,7 @@ async fn main() -> eyre::Result<()> {
             mount_options,
             granularity,
             no_copy,
+            reinit,
         }) => {
             commands::init_from::run(
                 virgin,
@@ -107,6 +110,7 @@ async fn main() -> eyre::Result<()> {
                 granularity,
                 no_copy,
                 cli.yes,
+                reinit,
             )
             .await
         }


### PR DESCRIPTION
## Summary
`-y` no longer blanket-approves all prompts. Reinitialize and destructive-proceed are now independent decisions.

## Changes
- Added `--reinit` flag to `init-new` and `init-from` — controls the "Reinitialize?" prompt separately from `-y`
- `confirm::require` now prints `[auto-confirmed] <message>` when a flag skips a prompt, so CI logs show what was approved
- Updated `SPEC.md` with a "Confirmation Semantics" section codifying that `-y` means "skip the primary destructive prompt", not "silently swallow all decisions"

## Testing
```
cargo test   # 16 passed, 4 ignored (require root)
cargo fmt --all --check   # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
```

Prompted by: pep