### PR TITLE
feat: add --version/-V flag with git SHA

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,4 +12,27 @@ fn main() {
             target, target_os
         );
     }
+
+    // Embed git SHA for --version output.
+    // Works with `cargo install --path .` (has .git dir) and
+    // `cargo install --git ...` (cargo sets GIT_SHA env var).
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs");
+    println!("cargo:rerun-if-env-changed=GIT_SHA");
+
+    let sha = std::env::var("GIT_SHA")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            std::process::Command::new("git")
+                .args(["rev-parse", "--short", "HEAD"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        });
+
+    if let Some(sha) = sha {
+        println!("cargo:rustc-env=SCHELK_GIT_SHA={}", sha);
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,10 +8,20 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 
+/// Version string including the git SHA when available (e.g. "0.1.0 (abc1234)").
+fn version_string() -> &'static str {
+    if let Some(sha) = option_env!("SCHELK_GIT_SHA") {
+        // Leak is fine — called once, lives for the program's lifetime.
+        Box::leak(format!("{} ({})", env!("CARGO_PKG_VERSION"), sha).into_boxed_str())
+    } else {
+        env!("CARGO_PKG_VERSION")
+    }
+}
+
 #[derive(Parser)]
 #[command(name = "schelk")]
 #[command(about = "Fast database benchmarking with surgical volume recovery")]
-#[command(version)]
+#[command(version = version_string())]
 pub struct Cli {
     /// Skip interactive confirmations
     #[arg(short = 'y', long = "yes", global = true)]


### PR DESCRIPTION
## Summary
Adds `--version`/`-V` flag that prints the git SHA schelk was built from, e.g. `schelk 0.1.0 (acd23e6)`.

## Changes
- `build.rs`: resolve short git SHA at build time via `git rev-parse --short HEAD` (for `cargo install --path .`) or `GIT_SHA` env var override
- `src/cli.rs`: wire `SCHELK_GIT_SHA` into clap's version string

## How it works
| Install method | SHA source |
|---|---|
| `cargo install --path .` | `git rev-parse --short HEAD` in the repo checkout |
| `cargo install --git ...` | same — cargo clones the repo, `.git` is present |
| `GIT_SHA=abc1234 cargo build` | env var override (CI, release builds) |
| No git, no env var | falls back to plain `0.1.0` |

## Testing
```
$ ./target/debug/schelk --version
schelk 0.1.0 (acd23e6)
$ ./target/debug/schelk -V
schelk 0.1.0 (acd23e6)
```

Prompted by: pep