### PR TITLE
feat: make dm-era device name configurable via state

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -43,6 +43,9 @@ Parameters:
 - the ram disk path.
 - mount point and the mount options.
 - granularity. Defaults to 4k.
+- dm-era device name. Defaults to `bench_era`. Override with `--dm-era-name` to run multiple 
+  schelk instances in parallel (each must use a unique name, separate state files, and separate
+  volumes/ramdisks).
 
 Steps:
 
@@ -77,6 +80,7 @@ Parameters:
 - the ram disk path.
 - mount point and the mount options.
 - granularity. Defaults to 4k.
+- dm-era device name. Defaults to `bench_era`. Same semantics as `init-new`.
 
 Steps:
 
@@ -116,11 +120,12 @@ Checks:
 1. Spot checks state of volumes and verifies that it is the same as the expected per the state of the 
 app.
 
-Zeroes the ramdisk and initializes dm-era for the scratch volume.
+Zeroes the ramdisk and initializes dm-era for the scratch volume using the configured device name
+(stored in state as `dm_era_name`, defaults to `bench_era`).
 
 ```
-dmsetup create bench_era ... era /dev/ram0 /dev/nvme_ <granularity>
-dmsetup message bench_era 0 checkpoint
+dmsetup create <dm_era_name> ... era /dev/ram0 /dev/nvme_ <granularity>
+dmsetup message <dm_era_name> 0 checkpoint
 ```
 
 Mounts the scratch volume at the specified location. 
@@ -141,15 +146,15 @@ from removing a filesystem while there is still some activity. That also flushes
 umount /schelk
 ```
  
-Take dm-era snapshot, invalidate. 
+Take dm-era snapshot, invalidate (using the `dm_era_name` from state). 
 
 ```
 # Create a clone of metadata for userspace reading.
-dmsetup message bench_era 0 take_metadata_snap
+dmsetup message <dm_era_name> 0 take_metadata_snap
 # Collect all the changed blocks into a file.
 era_invalidate --metadata-snapshot --written-since "$BASE" /dev/ram0 > changed.xml
 # Drop the metadata snapshot.
-dmsetup message bench_era 0 drop_metadata_snap
+dmsetup message <dm_era_name> 0 drop_metadata_snap
 ```
 
 At this point we obtained `changed.xml` containing all the blocks to restore.
@@ -161,7 +166,7 @@ At this point we obtained `changed.xml` containing all the blocks to restore.
 We should tear down the device mapper.
 
 ```
-dmsetup remove bench_era
+dmsetup remove <dm_era_name>
 ```
 
 And then perform copy of the blocks from the virgin to scratch according to `changed.xml`. The 
@@ -193,14 +198,14 @@ Steps:
 2. **Collect changed blocks via dm-era.** Same metadata snapshot and `era_invalidate` flow as 
    `recover`:
    ```
-   dmsetup message bench_era 0 take_metadata_snap
+   dmsetup message <dm_era_name> 0 take_metadata_snap
    era_invalidate --metadata-snapshot --written-since <base_era> /dev/ram0 > changed.xml
-   dmsetup message bench_era 0 drop_metadata_snap
+   dmsetup message <dm_era_name> 0 drop_metadata_snap
    ```
 
 3. **Tear down dm-era.**
    ```
-   dmsetup remove bench_era
+   dmsetup remove <dm_era_name>
    ```
 
 4. **Copy changed blocks from scratch to virgin.** This is the key difference from `recover`: the
@@ -222,6 +227,11 @@ Reports the current status.
 The app state lives in `/var/lib/schelk/state.json`. This is a system-wide location because schelk
 requires root privileges to operate (dm-era, mount, block device access). Using a fixed path avoids
 confusion when running with `sudo` (which would otherwise use root's home directory for XDG paths).
+
+The state includes a `dm_era_name` field (the device-mapper name for the dm-era target). This 
+defaults to `bench_era` and is backwards-compatible: older state files without this field will use
+the default. To run multiple schelk instances in parallel, use `--state-path` with separate state
+files and `--dm-era-name` with unique names per instance.
 
 Every update should be performed robustly: atomic updates (write to temp file, fsync, rename), 
 `fsync` the directory, etc.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,6 +8,8 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 
+use crate::dmera;
+
 /// Version string including the git SHA when available (e.g. "0.1.0 (abc1234)").
 fn version_string() -> &'static str {
     if let Some(sha) = option_env!("SCHELK_GIT_SHA") {
@@ -63,6 +65,10 @@ pub enum Command {
         /// Block granularity in bytes
         #[arg(long, default_value = "4096")]
         granularity: u64,
+
+        /// Device-mapper name for the dm-era target (allows parallel instances)
+        #[arg(long, default_value = dmera::DEFAULT_DM_ERA_NAME)]
+        dm_era_name: String,
     },
 
     /// Adopt an existing pre-populated virgin volume (destructive to scratch)
@@ -95,6 +101,10 @@ pub enum Command {
         /// Block granularity in bytes
         #[arg(long, default_value = "4096")]
         granularity: u64,
+
+        /// Device-mapper name for the dm-era target (allows parallel instances)
+        #[arg(long, default_value = dmera::DEFAULT_DM_ERA_NAME)]
+        dm_era_name: String,
 
         /// Skip copying virgin to scratch
         #[arg(long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -66,7 +66,7 @@ pub enum Command {
         #[arg(long, default_value = "4096")]
         granularity: u64,
 
-        /// Device-mapper name for the dm-era target (allows parallel instances)
+        /// Device-mapper name for the dm-era target.
         #[arg(long, default_value = dmera::DEFAULT_DM_ERA_NAME)]
         dm_era_name: String,
     },
@@ -102,7 +102,7 @@ pub enum Command {
         #[arg(long, default_value = "4096")]
         granularity: u64,
 
-        /// Device-mapper name for the dm-era target (allows parallel instances)
+        /// Device-mapper name for the dm-era target.
         #[arg(long, default_value = dmera::DEFAULT_DM_ERA_NAME)]
         dm_era_name: String,
 

--- a/src/commands/init_from.rs
+++ b/src/commands/init_from.rs
@@ -18,6 +18,7 @@ use std::time::Instant;
 use eyre::{Result, eyre};
 
 use crate::confirm;
+use crate::dmera;
 use crate::env;
 use crate::ramdisk;
 use crate::state::{self, AppState};
@@ -33,6 +34,7 @@ pub async fn run(
     fstype: String,
     mount_options: Option<String>,
     granularity: u64,
+    dm_era_name: String,
     no_copy: bool,
     yes: bool,
 ) -> Result<()> {
@@ -40,6 +42,7 @@ pub async fn run(
 
     super::init_common::validate_granularity(granularity)?;
     super::init_common::reject_same_device(&virgin, &scratch)?;
+    dmera::validate_name(&dm_era_name)?;
 
     // Check if already initialized.
     if let Some(existing) = state::load()? {
@@ -142,6 +145,7 @@ pub async fn run(
         mount_options,
         granularity,
         virgin_superblock_hash,
+        dm_era_name,
         is_mounted: false,
         current_era: None,
     };

--- a/src/commands/init_new.rs
+++ b/src/commands/init_new.rs
@@ -14,12 +14,14 @@ use std::time::Instant;
 use eyre::{Result, eyre};
 
 use crate::confirm;
+use crate::dmera;
 use crate::env;
 use crate::ramdisk;
 use crate::state::{self, AppState};
 use crate::volume;
 
 /// Run the init-new command
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     virgin: PathBuf,
     scratch: PathBuf,
@@ -27,12 +29,14 @@ pub async fn run(
     mount_point: PathBuf,
     mount_options: Option<String>,
     granularity: u64,
+    dm_era_name: String,
     yes: bool,
 ) -> Result<()> {
     env::require_root()?;
 
     super::init_common::validate_granularity(granularity)?;
     super::init_common::reject_same_device(&virgin, &scratch)?;
+    dmera::validate_name(&dm_era_name)?;
 
     // Check that mkfs.ext4 is available before doing anything else
     volume::check_mkfs_ext4().await?;
@@ -133,6 +137,7 @@ pub async fn run(
         mount_options,
         granularity,
         virgin_superblock_hash,
+        dm_era_name,
         is_mounted: false,
         current_era: None,
     };

--- a/src/commands/init_new.rs
+++ b/src/commands/init_new.rs
@@ -21,7 +21,7 @@ use crate::state::{self, AppState};
 use crate::volume;
 
 /// Run the init-new command
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub async fn run(
     virgin: PathBuf,
     scratch: PathBuf,

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -9,7 +9,7 @@
 //
 // Operation:
 //   1. Zero the RAM disk
-//   2. Create dm-era device: dmsetup create bench_era ... era /dev/ram0 /dev/scratch <granularity>
+//   2. Create dm-era device: dmsetup create <dm_era_name> ... era /dev/ram0 /dev/scratch <granularity>
 //   3. Mount the dm-era device at the configured mount point
 //   4. Update app state to mark as mounted
 //
@@ -49,13 +49,13 @@ pub async fn run() -> Result<()> {
     dmera::check_dmsetup().await?;
 
     // Check if dm-era device already exists (stale state from crash?)
-    if dmera::exists(dmera::DM_ERA_NAME).await? {
+    if dmera::exists(&app_state.dm_era_name).await? {
         return Err(eyre::eyre!(
             "dm-era device '{}' already exists.\n\
              This may indicate a previous crash. Run 'schelk recover' or manually remove with:\n  \
              sudo dmsetup remove {}",
-            dmera::DM_ERA_NAME,
-            dmera::DM_ERA_NAME
+            app_state.dm_era_name,
+            app_state.dm_era_name
         ));
     }
 
@@ -87,9 +87,9 @@ pub async fn run() -> Result<()> {
     io::zero(&app_state.ramdisk)?;
 
     // Step 4: Create dm-era device
-    println!("Creating dm-era device...");
+    println!("Creating dm-era device '{}'...", app_state.dm_era_name);
     if let Err(e) = dmera::create(
-        dmera::DM_ERA_NAME,
+        &app_state.dm_era_name,
         &app_state.ramdisk,
         &app_state.scratch,
         scratch_size,
@@ -102,19 +102,19 @@ pub async fn run() -> Result<()> {
 
     // Step 5: Checkpoint to start era tracking
     println!("Initializing era tracking...");
-    if let Err(e) = dmera::checkpoint(dmera::DM_ERA_NAME).await {
+    if let Err(e) = dmera::checkpoint(&app_state.dm_era_name).await {
         // Rollback: remove dm-era device on failure
-        let _ = dmera::remove(dmera::DM_ERA_NAME).await;
+        let _ = dmera::remove(&app_state.dm_era_name).await;
         return Err(e.wrap_err("Failed to checkpoint dm-era device"));
     }
 
     // Step 6: Mount the dm-era device
+    let dm_device = dmera::device_path(&app_state.dm_era_name);
     println!(
         "Mounting {} at {}...",
-        dmera::device_path().display(),
+        dm_device.display(),
         app_state.mount_point.display()
     );
-    let dm_device = dmera::device_path();
     if let Err(e) = mount::mount(
         &dm_device,
         &app_state.mount_point,
@@ -124,7 +124,7 @@ pub async fn run() -> Result<()> {
     .await
     {
         // Rollback: remove dm-era device on mount failure
-        let _ = dmera::remove(dmera::DM_ERA_NAME).await;
+        let _ = dmera::remove(&app_state.dm_era_name).await;
         return Err(e.wrap_err("Failed to mount dm-era device"));
     }
 

--- a/src/commands/promote.rs
+++ b/src/commands/promote.rs
@@ -37,6 +37,8 @@ use crate::{dmera, env, mount, state, volume};
 pub async fn run(yes: bool, kill: bool) -> Result<()> {
     env::require_root()?;
 
+    let _lock = state::lock()?;
+
     let app_state = state::load()?.ok_or_else(not_initialized)?;
 
     if !app_state.is_mounted {
@@ -50,12 +52,12 @@ pub async fn run(yes: bool, kill: bool) -> Result<()> {
     dmera::check_era_invalidate().await?;
 
     // Verify dm-era device actually exists
-    if !dmera::exists(dmera::DM_ERA_NAME).await? {
+    if !dmera::exists(&app_state.dm_era_name).await? {
         return Err(eyre!(
             "dm-era device '{}' does not exist.\n\
              State says mounted but device is missing. This may indicate a system crash.\n\
              Run 'schelk mount' to remount, or manually reset state.",
-            dmera::DM_ERA_NAME
+            app_state.dm_era_name
         ));
     }
 
@@ -85,7 +87,7 @@ pub async fn run(yes: bool, kill: bool) -> Result<()> {
 
     // Step 2: Take dm-era metadata snapshot
     println!("Taking dm-era metadata snapshot...");
-    dmera::take_metadata_snapshot(dmera::DM_ERA_NAME)
+    dmera::take_metadata_snapshot(&app_state.dm_era_name)
         .await
         .wrap_err("Failed to take metadata snapshot")?;
 
@@ -95,20 +97,20 @@ pub async fn run(yes: bool, kill: bool) -> Result<()> {
         Ok(blocks) => blocks,
         Err(e) => {
             // Try to drop the metadata snapshot before returning error
-            let _ = dmera::drop_metadata_snapshot(dmera::DM_ERA_NAME).await;
+            let _ = dmera::drop_metadata_snapshot(&app_state.dm_era_name).await;
             return Err(e.wrap_err("Failed to collect changed blocks"));
         }
     };
 
     // Step 4: Drop metadata snapshot
     println!("Dropping metadata snapshot...");
-    dmera::drop_metadata_snapshot(dmera::DM_ERA_NAME)
+    dmera::drop_metadata_snapshot(&app_state.dm_era_name)
         .await
         .wrap_err("Failed to drop metadata snapshot")?;
 
     // Step 5: Remove dm-era device
     println!("Removing dm-era device...");
-    dmera::remove(dmera::DM_ERA_NAME)
+    dmera::remove(&app_state.dm_era_name)
         .await
         .wrap_err("Failed to remove dm-era device")?;
 

--- a/src/commands/promote.rs
+++ b/src/commands/promote.rs
@@ -103,7 +103,7 @@ pub async fn run(yes: bool, kill: bool) -> Result<()> {
     };
 
     // Step 4: Drop metadata snapshot
-    println!("Dropping metadata snapshot...");
+    println!("Dropping metadata snapshot for '{}'...", app_state.dm_era_name);
     dmera::drop_metadata_snapshot(&app_state.dm_era_name)
         .await
         .wrap_err("Failed to drop metadata snapshot")?;

--- a/src/commands/promote.rs
+++ b/src/commands/promote.rs
@@ -103,7 +103,10 @@ pub async fn run(yes: bool, kill: bool) -> Result<()> {
     };
 
     // Step 4: Drop metadata snapshot
-    println!("Dropping metadata snapshot for '{}'...", app_state.dm_era_name);
+    println!(
+        "Dropping metadata snapshot for '{}'...",
+        app_state.dm_era_name
+    );
     dmera::drop_metadata_snapshot(&app_state.dm_era_name)
         .await
         .wrap_err("Failed to drop metadata snapshot")?;

--- a/src/commands/recover.rs
+++ b/src/commands/recover.rs
@@ -93,7 +93,7 @@ pub async fn run(kill: bool) -> Result<()> {
     };
 
     // Step 4: Drop metadata snapshot
-    println!("Dropping metadata snapshot...");
+    println!("Dropping metadata snapshot for '{}'...", app_state.dm_era_name);
     dmera::drop_metadata_snapshot(&app_state.dm_era_name)
         .await
         .wrap_err("Failed to drop metadata snapshot")?;

--- a/src/commands/recover.rs
+++ b/src/commands/recover.rs
@@ -93,7 +93,10 @@ pub async fn run(kill: bool) -> Result<()> {
     };
 
     // Step 4: Drop metadata snapshot
-    println!("Dropping metadata snapshot for '{}'...", app_state.dm_era_name);
+    println!(
+        "Dropping metadata snapshot for '{}'...",
+        app_state.dm_era_name
+    );
     dmera::drop_metadata_snapshot(&app_state.dm_era_name)
         .await
         .wrap_err("Failed to drop metadata snapshot")?;

--- a/src/commands/recover.rs
+++ b/src/commands/recover.rs
@@ -8,10 +8,10 @@
 //
 // Operation:
 //   1. Unmount the filesystem (flushes writes, prevents further modifications)
-//   2. Take dm-era metadata snapshot: dmsetup message bench_era 0 take_metadata_snap
+//   2. Take dm-era metadata snapshot: dmsetup message <dm_era_name> 0 take_metadata_snap
 //   3. Collect changed blocks: era_invalidate --metadata-snapshot --written-since <era> /dev/ram0 > changed.xml
-//   4. Drop metadata snapshot: dmsetup message bench_era 0 drop_metadata_snap
-//   5. Remove dm-era device: dmsetup remove bench_era
+//   4. Drop metadata snapshot: dmsetup message <dm_era_name> 0 drop_metadata_snap
+//   5. Remove dm-era device: dmsetup remove <dm_era_name>
 //   6. Parse changed.xml and copy affected blocks from virgin to scratch
 //   7. Update app state (clear mounted flag, remove changed.xml)
 //
@@ -47,12 +47,12 @@ pub async fn run(kill: bool) -> Result<()> {
     dmera::check_era_invalidate().await?;
 
     // Verify dm-era device actually exists
-    if !dmera::exists(dmera::DM_ERA_NAME).await? {
+    if !dmera::exists(&app_state.dm_era_name).await? {
         return Err(eyre!(
             "dm-era device '{}' does not exist.\n\
              State says mounted but device is missing. This may indicate a system crash.\n\
              Run 'schelk mount' to remount, or manually reset state.",
-            dmera::DM_ERA_NAME
+            app_state.dm_era_name
         ));
     }
 
@@ -77,7 +77,7 @@ pub async fn run(kill: bool) -> Result<()> {
 
     // Step 2: Take dm-era metadata snapshot
     println!("Taking dm-era metadata snapshot...");
-    dmera::take_metadata_snapshot(dmera::DM_ERA_NAME)
+    dmera::take_metadata_snapshot(&app_state.dm_era_name)
         .await
         .wrap_err("Failed to take metadata snapshot")?;
 
@@ -87,20 +87,20 @@ pub async fn run(kill: bool) -> Result<()> {
         Ok(blocks) => blocks,
         Err(e) => {
             // Try to drop the metadata snapshot before returning error
-            let _ = dmera::drop_metadata_snapshot(dmera::DM_ERA_NAME).await;
+            let _ = dmera::drop_metadata_snapshot(&app_state.dm_era_name).await;
             return Err(e.wrap_err("Failed to collect changed blocks"));
         }
     };
 
     // Step 4: Drop metadata snapshot
     println!("Dropping metadata snapshot...");
-    dmera::drop_metadata_snapshot(dmera::DM_ERA_NAME)
+    dmera::drop_metadata_snapshot(&app_state.dm_era_name)
         .await
         .wrap_err("Failed to drop metadata snapshot")?;
 
     // Step 5: Remove dm-era device
     println!("Removing dm-era device...");
-    dmera::remove(dmera::DM_ERA_NAME)
+    dmera::remove(&app_state.dm_era_name)
         .await
         .wrap_err("Failed to remove dm-era device")?;
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -43,9 +43,10 @@ pub async fn run() -> Result<()> {
                 println!("  Mount options:  {}", opts);
             }
             println!("  Granularity:    {} bytes", state.granularity);
+            println!("  dm-era name:    {}", state.dm_era_name);
             println!();
             println!("Runtime status:");
-            let device_exists = dmera::exists(dmera::DM_ERA_NAME).await.unwrap_or(false);
+            let device_exists = dmera::exists(&state.dm_era_name).await.unwrap_or(false);
             let actually_mounted = mount::is_mounted(&state.mount_point).unwrap_or(false);
 
             if state.is_mounted {

--- a/src/dmera.rs
+++ b/src/dmera.rs
@@ -11,12 +11,35 @@ use quick_xml::events::Event;
 use crate::cmd;
 use crate::volume;
 
-/// Default device name for the dm-era target
-pub const DM_ERA_NAME: &str = "bench_era";
+/// Default device name for the dm-era target.
+pub const DEFAULT_DM_ERA_NAME: &str = "bench_era";
 
-/// Path to the dm-era device in /dev/mapper
-pub fn device_path() -> std::path::PathBuf {
-    std::path::PathBuf::from("/dev/mapper").join(DM_ERA_NAME)
+/// Path to the dm-era device in /dev/mapper for the given device name.
+pub fn device_path(name: &str) -> std::path::PathBuf {
+    std::path::PathBuf::from("/dev/mapper").join(name)
+}
+
+/// Validate that a dm-era device name is safe for use with dmsetup and /dev/mapper paths.
+pub fn validate_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(eyre!("dm-era name must not be empty"));
+    }
+    if name.starts_with('-') {
+        return Err(eyre!(
+            "dm-era name must not start with '-' (got '{}')",
+            name
+        ));
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || "._+-".contains(c))
+    {
+        return Err(eyre!(
+            "dm-era name '{}' contains invalid characters (allowed: A-Z, a-z, 0-9, '.', '_', '+', '-')",
+            name
+        ));
+    }
+    Ok(())
 }
 
 /// Check that dmsetup is available in PATH
@@ -254,6 +277,31 @@ fn parse_era_invalidate_xml(xml: &str) -> Result<Vec<volume::BlockRange>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn validate_name_accepts_defaults() {
+        validate_name("bench_era").unwrap();
+        validate_name("bench_era_2").unwrap();
+        validate_name("my.instance+1").unwrap();
+    }
+
+    #[test]
+    fn validate_name_rejects_empty() {
+        assert!(validate_name("").is_err());
+    }
+
+    #[test]
+    fn validate_name_rejects_leading_dash() {
+        assert!(validate_name("-bad").is_err());
+        assert!(validate_name("--help").is_err());
+    }
+
+    #[test]
+    fn validate_name_rejects_path_separators() {
+        assert!(validate_name("../etc/passwd").is_err());
+        assert!(validate_name("/dev/sda1").is_err());
+        assert!(validate_name("bad name").is_err());
+    }
 
     #[test]
     fn test_parse_era_invalidate_xml() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,7 @@ async fn main() -> eyre::Result<()> {
             mount_point,
             mount_options,
             granularity,
+            dm_era_name,
         }) => {
             commands::init_new::run(
                 virgin,
@@ -83,6 +84,7 @@ async fn main() -> eyre::Result<()> {
                 mount_point,
                 mount_options,
                 granularity,
+                dm_era_name,
                 cli.yes,
             )
             .await
@@ -95,6 +97,7 @@ async fn main() -> eyre::Result<()> {
             fstype,
             mount_options,
             granularity,
+            dm_era_name,
             no_copy,
         }) => {
             commands::init_from::run(
@@ -105,6 +108,7 @@ async fn main() -> eyre::Result<()> {
                 fstype,
                 mount_options,
                 granularity,
+                dm_era_name,
                 no_copy,
                 cli.yes,
             )

--- a/src/state.rs
+++ b/src/state.rs
@@ -12,6 +12,8 @@ use serde::{Deserialize, Serialize};
 
 use std::sync::OnceLock;
 
+use crate::dmera;
+
 // TODO: I think we should specify a directory, and then that directory should store the `state`
 // file. This may come in handy in case we would like to recover from a failure during copying
 // changed blocks out of the virgin to the scratch.
@@ -19,6 +21,10 @@ const DEFAULT_STATE_PATH: &str = "/var/lib/schelk/state.json";
 
 /// Global override for state file path (set via CLI or env var)
 static STATE_PATH_OVERRIDE: OnceLock<PathBuf> = OnceLock::new();
+
+fn default_dm_era_name() -> String {
+    dmera::DEFAULT_DM_ERA_NAME.to_string()
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppState {
@@ -40,6 +46,10 @@ pub struct AppState {
     /// SHA-256 hash of virgin superblock for integrity checks
     /// Scratch superblock should always match this (before mount and after recover)
     pub virgin_superblock_hash: [u8; 32],
+    /// Device-mapper name for the dm-era target (e.g., "bench_era").
+    /// Defaults to "bench_era" when absent (backwards-compatible with older state files).
+    #[serde(default = "default_dm_era_name")]
+    pub dm_era_name: String,
     /// Whether dm-era is active and volume is mounted
     pub is_mounted: bool,
     /// Current dm-era epoch for tracking changes
@@ -187,6 +197,45 @@ mod tests {
         let first = lock_path(&lf).expect("first lock should succeed");
         drop(first);
         let _second = lock_path(&lf).expect("lock should succeed after drop");
+    }
+
+    #[test]
+    fn old_state_without_dm_era_name_uses_default() {
+        // Simulate a state file from before dm_era_name was added
+        let json = r#"{
+            "virgin": "/dev/nvme1n1",
+            "scratch": "/dev/nvme2n1",
+            "ramdisk": "/dev/ram0",
+            "mount_point": "/schelk",
+            "fstype": "ext4",
+            "mount_options": null,
+            "granularity": 4096,
+            "virgin_superblock_hash": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+            "is_mounted": false,
+            "current_era": null
+        }"#;
+        let state: AppState = serde_json::from_str(json).unwrap();
+        assert_eq!(state.dm_era_name, dmera::DEFAULT_DM_ERA_NAME);
+    }
+
+    #[test]
+    fn custom_dm_era_name_roundtrips() {
+        let state = AppState {
+            virgin: PathBuf::from("/dev/a"),
+            scratch: PathBuf::from("/dev/b"),
+            ramdisk: PathBuf::from("/dev/ram0"),
+            mount_point: PathBuf::from("/mnt"),
+            fstype: "ext4".to_string(),
+            mount_options: None,
+            granularity: 4096,
+            virgin_superblock_hash: [0u8; 32],
+            dm_era_name: "my_custom_era".to_string(),
+            is_mounted: false,
+            current_era: None,
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        let loaded: AppState = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.dm_era_name, "my_custom_era");
     }
 
     #[test]


### PR DESCRIPTION
Stores `dm_era_name` in `state.json` instead of hardcoding `bench_era`, enabling multiple parallel schelk instances.

## Changes

- Add `--dm-era-name` flag to `init-new` / `init-from` (defaults to `bench_era`)
- Add `dm_era_name` field to `AppState` with `#[serde(default)]` for backwards compat with old state files
- All commands now read the name from state instead of the `DM_ERA_NAME` constant
- `device_path()` takes a `&str` parameter instead of using the constant
- `validate_name()` rejects empty strings, leading dashes, path separators, and whitespace
- Add `_lock` to `promote` command (was missing, unlike `mount`/`recover`)
- Deduplicate CLI default value to use `dmera::DEFAULT_DM_ERA_NAME`
- Update SPEC.md: all `bench_era` references now use `<dm_era_name>`, document the new parameter and state field

## Testing

```
cargo test -- state:: dmera:: init_common::   # 17 passed, 1 ignored (needs root)
cargo clippy --workspace --all-targets        # clean
cargo fmt --all --check                       # clean
```

New tests:
- `validate_name_accepts_defaults`, `validate_name_rejects_empty`, `validate_name_rejects_leading_dash`, `validate_name_rejects_path_separators`
- `old_state_without_dm_era_name_uses_default` (backwards compat)
- `custom_dm_era_name_roundtrips` (serde round-trip)

Prompted by: pep