### PR TITLE
fix: acquire flock in init-new, init-from, and full-recover

### DIFF
--- a/src/commands/full_recover.rs
+++ b/src/commands/full_recover.rs
@@ -29,6 +29,8 @@ use crate::volume;
 pub async fn run(yes: bool) -> Result<()> {
     env::require_root()?;
 
+    let _lock = state::lock()?;
+
     let mut app_state = state::load()?.ok_or_else(not_initialized)?;
 
     if app_state.is_mounted {

--- a/src/commands/init_from.rs
+++ b/src/commands/init_from.rs
@@ -40,6 +40,8 @@ pub async fn run(
 ) -> Result<()> {
     env::require_root()?;
 
+    let _lock = state::lock()?;
+
     super::init_common::validate_granularity(granularity)?;
     super::init_common::reject_same_device(&virgin, &scratch)?;
     dmera::validate_name(&dm_era_name)?;

--- a/src/commands/init_new.rs
+++ b/src/commands/init_new.rs
@@ -34,6 +34,8 @@ pub async fn run(
 ) -> Result<()> {
     env::require_root()?;
 
+    let _lock = state::lock()?;
+
     super::init_common::validate_granularity(granularity)?;
     super::init_common::reject_same_device(&virgin, &scratch)?;
     dmera::validate_name(&dm_era_name)?;


### PR DESCRIPTION
mount, recover, and promote all acquire an exclusive flock to prevent concurrent schelk operations. init-new, init-from, and full-recover did not, despite mutating volumes and state. This adds the same `state::lock()` call to all three.

status remains unlocked (read-only).

Prompted by: pep