### PR TITLE
fix: defer stale-mount state save until after full-recover copy

### DIFF
--- a/ci/vm-init.sh
+++ b/ci/vm-init.sh
@@ -613,6 +613,58 @@ schelk recover --state-path /tmp/state_b/state.json 2>&1 >/dev/null
 teardown /tmp/s10a /tmp/s10b
 
 ###########################################################################
+# Story 11: Full recover with stale mounted state (simulated reboot)
+#
+# After a reboot the state file still says "mounted" but the dm-era
+# device and filesystem mount are gone.  full-recover should detect this
+# stale state, auto-clear it, and proceed with the copy.
+###########################################################################
+story "STORY 11: Full recover with stale mounted state (simulated reboot)"
+
+teardown /tmp/s11
+setup_volumes /tmp/s11
+
+assert_ok "init-new" schelk init-new \
+    --virgin "$VIRGIN" --scratch "$SCRATCH" --ramdisk "$RAMDISK" \
+    --mount-point "$MP" -y
+
+assert_ok "mount" schelk mount
+echo "pre-reboot data" > "$MP/pre_reboot.txt"
+sync
+
+# Simulate reboot: tear down dm-era and unmount, but leave state as-is.
+# After this, state says is_mounted=true but nothing is actually live.
+umount "$MP" 2>/dev/null
+dmsetup remove bench_era 2>/dev/null
+
+# full-recover should detect the stale state and proceed
+assert_ok "full-recover with stale state" schelk full-recover -y
+
+# Verify system is usable afterward
+assert_ok "mount after stale full-recover" schelk mount
+is_mounted "$MP" || fail "mount after stale full-recover" "not mounted"
+
+# Data should be gone — we never promoted, so virgin has no pre_reboot.txt
+if [ ! -f "$MP/pre_reboot.txt" ]; then
+    pass "stale full-recover restored virgin correctly"
+else
+    fail "stale full-recover content" "pre_reboot.txt survived"
+fi
+
+assert_ok "recover (cleanup)" schelk recover
+
+# Edge case: if dm-era device is still live, full-recover must reject.
+# Simulate by mounting normally then only unmounting the filesystem.
+assert_ok "remount for edge case" schelk mount
+umount "$MP" 2>/dev/null
+# dm-era device is still live — full-recover should refuse
+assert_fail "full-recover rejects when dm-era still exists" schelk full-recover -y
+
+# Clean up the live dm-era device
+dmsetup remove bench_era 2>/dev/null
+teardown /tmp/s11
+
+###########################################################################
 # Story 12: Recover is a no-op when not mounted
 #
 # From user-stories.md story 18: recover should exit 0 when the volume

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -95,6 +95,12 @@ them outside of schelk may ruin them.
 Performs copy from the virgin to the scratch. This is very costly and should be ideally performed 
 only once. Must be confirmed either by -y.
 
+If the state says "mounted" but neither the dm-era device nor the filesystem mount actually exist
+(e.g., after a host reboot or power loss), `full-recover` detects this stale state, clears it, and
+proceeds with the copy. If either the dm-era device or the mount is still live, it refuses with
+"already mounted". The stale flag is only persisted as part of the final state save after the copy
+completes — if `full-recover` crashes mid-copy the stale detection will re-trigger on the next run.
+
 ### `mount`
 
 Checks:

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -82,7 +82,8 @@ this and guide me to a safe recovery path.
 Steps:
 1. `schelk mount` → start the SUT → reboot the host.
 2. `schelk recover` — should refuse incremental recovery and instruct to run `full-recover`.
-3. `schelk full-recover` — restores scratch from virgin.
+3. `schelk full-recover` — detects that state says "mounted" but dm-era device and filesystem
+   are gone, auto-clears the stale flag, and restores scratch from virgin.
 4. Verify the SUT starts cleanly.
 
 ## 8. Full recovery fallback

--- a/src/commands/full_recover.rs
+++ b/src/commands/full_recover.rs
@@ -49,7 +49,8 @@ pub async fn run(yes: bool) -> Result<()> {
 
         app_state.is_mounted = false;
         app_state.current_era = None;
-        state::save(&app_state)?;
+        // Don't save yet — if we crash mid-copy the stale detection will
+        // re-trigger on the next run, which is the safe behavior.
     }
 
     // Validate volumes are accessible


### PR DESCRIPTION
## Problem

The previous commit (dd94c9e) added stale-mount detection to `full-recover` but saved the cleared state **before** the block copy. If `full-recover` crashed mid-copy, the state would claim "not mounted" while scratch was left half-written — and `mount`'s superblock check could pass, letting the user mount a corrupt volume.

## Fix

Defer the state save so it happens once at the end, after the copy and superblock hash update. If `full-recover` crashes mid-copy, the stale detection re-triggers idempotently on the next run.

## Tests

Added Story 11 to the QEMU integration tests:
- **Happy path**: simulate reboot (tear down dm-era + unmount, state still says mounted) → `full-recover -y` detects stale state, proceeds, mount works, data restored correctly from virgin.
- **Edge case**: leave dm-era device live but unmount fs → `full-recover -y` correctly rejects with "already mounted".

## Docs

- `spec.md`: expanded `full-recover` section with stale state detection, rejection logic, and crash-safe deferred save.
- `user-stories.md`: updated story #7 step 3 to describe the auto-clearing behavior.