### PR TITLE
fix: recover exits 0 when volume is not mounted

### DIFF
--- a/ci/vm-init.sh
+++ b/ci/vm-init.sh
@@ -613,6 +613,36 @@ schelk recover --state-path /tmp/state_b/state.json 2>&1 >/dev/null
 teardown /tmp/s10a /tmp/s10b
 
 ###########################################################################
+# Story 12: Recover is a no-op when not mounted
+#
+# From user-stories.md story 18: recover should exit 0 when the volume
+# is not mounted.  This matters for CI scripts that run
+# `schelk recover || schelk full-recover` — a non-zero exit from
+# recover when nothing is mounted would trigger an unnecessary
+# full-recover.
+###########################################################################
+story "STORY 12: Recover is a no-op when not mounted"
+
+teardown /tmp/s12
+setup_volumes /tmp/s12
+
+assert_ok "init-new" schelk init-new \
+    --virgin "$VIRGIN" --scratch "$SCRATCH" --ramdisk "$RAMDISK" \
+    --mount-point "$MP" -y
+
+# Never mounted — recover should succeed (no-op)
+assert_ok "recover when never mounted" schelk recover
+
+# Mount, recover normally, then recover again — second should be no-op
+assert_ok "mount" schelk mount
+echo "data" > "$MP/data.txt"
+sync
+assert_ok "recover (normal)" schelk recover
+assert_ok "recover again (already recovered)" schelk recover
+
+teardown /tmp/s12
+
+###########################################################################
 # Results
 ###########################################################################
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -118,8 +118,10 @@ It should be fool proof, in that it should not allow mount after amount.
  
 Pre-checks:
  
-- make sure that the mount previously happened. This should be performed by reading the app state
-  first.
+- If the volume is not mounted (`is_mounted` is false in app state), there is nothing to recover.
+  This is a no-op: print a message and exit successfully (exit code 0). This is important for
+  scripting — callers like CI pipelines should be able to run `schelk recover` unconditionally
+  without it triggering unnecessary fallback logic (e.g., a costly `full-recover`).
 - `dmsetup`, `era_invalidate` is available in the PATH.
 
 Unmount the filesystem first. This prevents further modifications and also would give a safeguard

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -186,7 +186,19 @@ Steps:
 2. Verify no dm-era device exists (`dmsetup ls` should not show `bench_era`).
 3. Verify no leftover `changed.xml` or temp files.
 
-## 18. Transparent action logging
+## 18. Recover is a no-op when not mounted
+
+As a CI pipeline author, I want `schelk recover` to succeed (exit 0) when the volume is not
+mounted, so that unconditional cleanup like `schelk recover || schelk full-recover` does not
+trigger an unnecessary full recovery.
+
+Steps:
+1. `schelk init-new ... -y` — initialize without mounting.
+2. `schelk recover` — should print that nothing is mounted and exit 0.
+3. `schelk mount` → `schelk recover` — normal recovery, also exit 0.
+4. `schelk recover` again — already recovered, should exit 0.
+
+## 19. Transparent action logging
 
 As a benchmarker, I want every action schelk takes to be printed to the screen so I can
 understand what happened and diagnose issues.

--- a/src/commands/recover.rs
+++ b/src/commands/recover.rs
@@ -37,7 +37,8 @@ pub async fn run(kill: bool) -> Result<()> {
     let app_state = state::load()?.ok_or_else(not_initialized)?;
 
     if !app_state.is_mounted {
-        return Err(not_mounted());
+        println!("Volume is not mounted. Nothing to recover.");
+        return Ok(());
     }
 
     let base_era = app_state.current_era.unwrap_or(0);
@@ -166,10 +167,6 @@ pub async fn run(kill: bool) -> Result<()> {
     }
 
     Ok(())
-}
-
-fn not_mounted() -> eyre::Report {
-    eyre!("Volume is not mounted.")
 }
 
 /// Format bytes in human-readable form


### PR DESCRIPTION
## Problem

`schelk recover` returned a non-zero exit code when the volume was not mounted. This is a perfectly normal state (fresh runner, or after a prior recover), but CI scripts like:

```sh
sudo schelk recover -y --kill || sudo schelk full-recover -y || true
```

would fall through to a costly `full-recover` unnecessarily. See paradigmxyz/reth#23472 for the workaround this eliminates.

## Fix

Treat not-mounted as a successful no-op: print a message and exit 0. Actual errors (stale dm-era state after reboot, missing device) still return non-zero.

## Tests

Added Story 12 to the QEMU integration tests:
- `recover` exits 0 when never mounted (after init, before any mount)
- `recover` exits 0 when called twice (already recovered)

## Docs

- `spec.md`: updated `recover` pre-checks to specify the no-op behavior and exit 0 semantics.
- `user-stories.md`: added story #18 covering the CI pipeline use case.