### PR TITLE
Fix clippy manual checked division warnings

### DIFF
--- a/src/commands/promote.rs
+++ b/src/commands/promote.rs
@@ -139,11 +139,7 @@ pub async fn run(yes: bool, kill: bool) -> Result<()> {
             &changed_blocks,
             app_state.granularity,
             |copied, total| {
-                let percent = if total > 0 {
-                    (copied * 100) / total
-                } else {
-                    100
-                };
+                let percent = copied.saturating_mul(100).checked_div(total).unwrap_or(100);
                 if percent != last_percent {
                     last_percent = percent;
                     print!("\r  Progress: {}%", percent);

--- a/src/commands/recover.rs
+++ b/src/commands/recover.rs
@@ -130,11 +130,7 @@ pub async fn run(kill: bool) -> Result<()> {
             &changed_blocks,
             app_state.granularity,
             |copied, total| {
-                let percent = if total > 0 {
-                    (copied * 100) / total
-                } else {
-                    100
-                };
+                let percent = copied.saturating_mul(100).checked_div(total).unwrap_or(100);
                 if percent != last_percent {
                     last_percent = percent;
                     print!("\r  Progress: {}%", percent);


### PR DESCRIPTION
### Motivation
- Clippy on nightly flagged manual division guarded by `if total > 0 { ... / total } else { ... }` as `manual_checked_ops`, which fails `-D warnings` when running `cargo +nightly clippy`.

### Description
- Replace manual guard-based percentage calculation with a checked division using `saturating_mul(100).checked_div(total).unwrap_or(100)` to avoid divide-by-zero and satisfy `clippy::manual_checked_ops`.
- Applied the change to the progress callbacks in `src/commands/recover.rs` and `src/commands/promote.rs`.
- Ran `cargo fmt --all` to keep formatting consistent.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Installed nightly `clippy` and ran `cargo +nightly clippy --all-targets -- -D warnings`, which passed with no warnings.
- Ran `cargo clippy --all-targets -- -D warnings` on the default toolchain, which also completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e780c9dc20832cb03daa998e73e1d0)