### PR TITLE
[codex] Add README callout for SKILL.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ systems with large on-disk state - databases, or blockchain execution clients li
 [reth](https://github.com/paradigmxyz/reth). For such systems, rebuilding the baseline between
 runs is slow, and snapshot layers distort the measurements we want to take.
 
+> [!TIP]
+> If you want Codex, Claude, or another coding agent to set up or operate schelk for you, start
+> it with [`docs/SKILL.md`](docs/SKILL.md) or point it directly at
+> <https://github.com/tempoxyz/schelk/blob/master/docs/SKILL.md>. That file tells the agent how to
+> install schelk, validate prerequisites, initialize volumes, and run the workflow safely.
+
 ## Why
 
 A good benchmarking loop has two requirements:


### PR DESCRIPTION
## What changed
- added a tip callout near the top of `README.md`
- pointed users to `docs/SKILL.md` and the canonical GitHub URL for it
- explained that the skill can guide an agent through install, prerequisite checks, initialization, and safe operation

## Why
The repository now has agent-oriented setup guidance, but the README did not surface it prominently for users who want Codex, Claude, or another agent to drive schelk setup and usage.

## Impact
Users who discover schelk through the README can now find the agent entrypoint immediately, before reading the rationale section.

## Validation
- `git diff --cached --check`
- manual review of the rendered Markdown structure in the source diff
