### PR TITLE
open raw block devices exclusively

### DIFF
--- a/ci/vm-init.sh
+++ b/ci/vm-init.sh
@@ -695,6 +695,49 @@ assert_ok "recover again (already recovered)" schelk recover
 teardown /tmp/s12
 
 ###########################################################################
+# Story 13: O_EXCL refuses to write to a volume mounted outside schelk
+#
+# From user-stories.md story 20 and SPEC.md principles 3 and 11
+# ("foolproof", "principle of least surprise"). If the user mounts virgin
+# or scratch outside of schelk, any subsequent destructive write would
+# silently corrupt the live filesystem. Opening the raw device with
+# O_EXCL lets the kernel reject the operation with EBUSY before any
+# block is written.
+###########################################################################
+story "STORY 13: Refuse writes to volumes mounted outside schelk"
+
+teardown /tmp/s13
+setup_volumes /tmp/s13
+
+assert_ok "init-new" schelk init-new \
+    --virgin "$VIRGIN" --scratch "$SCRATCH" --ramdisk "$RAMDISK" \
+    --mount-point "$MP" -y
+
+# Mount scratch directly, outside schelk's control. After init-new the
+# scratch volume is byte-identical to virgin and carries a valid ext4 fs.
+mkdir -p /tmp/s13_external
+mount -t ext4 "$SCRATCH" /tmp/s13_external
+
+# full-recover writes to scratch. With O_EXCL on the destination open,
+# the kernel must reject it because scratch is currently mounted.
+assert_fail "full-recover refuses when scratch is mounted externally" \
+    schelk full-recover -y
+
+# Error message should clearly explain that the device is in use.
+echo "$LAST_OUT" | grep -qi "in use" && \
+    pass "error mentions 'in use'" || \
+    fail "error message" "did not mention 'in use'"
+
+# Unmounting the external mount must let full-recover succeed.
+umount /tmp/s13_external
+
+assert_ok "full-recover succeeds after external unmount" \
+    schelk full-recover -y
+
+umount /tmp/s13_external 2>/dev/null || true
+teardown /tmp/s13 /tmp/s13_external
+
+###########################################################################
 # Results
 ###########################################################################
 

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -208,3 +208,19 @@ Steps:
 1. Run `schelk init-new ... -y` and observe output — should print each step (mkfs, copy, hash).
 2. Run `schelk mount` — should print dm-era setup and mount actions.
 3. Run `schelk recover` — should print unmount, era snapshot, block copy progress, and cleanup.
+
+## 20. Refuse to write to a volume mounted outside schelk
+
+As a benchmarker, I sometimes mount virgin or scratch outside of schelk by mistake (e.g.,
+running `mount` for a quick inspection and forgetting to unmount). If I then run a destructive
+operation that writes to that volume — `init-from`, `full-recover`, `recover`, or `promote` —
+I want schelk to refuse before any block is written, so the live mounted filesystem is not
+corrupted from underneath.
+
+Steps:
+1. `schelk init-new ... -y` — initialize as usual.
+2. Manually mount the scratch volume outside schelk
+   (e.g., `mount /dev/scratch /mnt/inspect`).
+3. `schelk full-recover -y` — should fail with a clear "device is in use" error before any
+   block is written.
+4. Unmount the volume and retry — should succeed.

--- a/src/io/uring.rs
+++ b/src/io/uring.rs
@@ -419,10 +419,31 @@ fn run_ring(
     Ok(())
 }
 
+// Volumes are always opened with O_EXCL. On Linux, applying O_EXCL to a block
+// device (without O_CREAT) makes the kernel reject the open with EBUSY whenever
+// the device is already in use — mounted, claimed by an active device-mapper
+// target, or held by another O_EXCL opener. That matches schelk's invariant
+// that virgin and scratch are exclusively managed: copying into a live volume
+// would corrupt it, and reading from a live volume would feed inconsistent
+// data into the next destination. Surfacing EBUSY here turns a silent data
+// hazard into a clear failure before any I/O is issued.
 fn open_direct(path: &Path, flags: OFlag) -> Result<OwnedFd> {
-    nix::fcntl::open(path, flags | OFlag::O_DIRECT, Mode::empty())
-        .map_err(eyre::Report::new)
-        .wrap_err_with(|| format!("Cannot open {}", path.display()))
+    match nix::fcntl::open(path, flags | OFlag::O_DIRECT | OFlag::O_EXCL, Mode::empty()) {
+        Ok(fd) => Ok(fd),
+        Err(errno) => {
+            let msg = if errno == nix::errno::Errno::EBUSY {
+                format!(
+                    "Cannot open {} exclusively: the device is in use \
+                     (mounted, claimed by an active dm-era target, or held \
+                     by another O_EXCL opener)",
+                    path.display()
+                )
+            } else {
+                format!("Cannot open {}", path.display())
+            };
+            Err(eyre::Report::new(errno).wrap_err(msg))
+        }
+    }
 }
 
 // This is the orchestration layer shared by both copy modes. It validates that


### PR DESCRIPTION
this should add guardrails against erasing a volume that is already mounted or otherwise used elsewhere.