### PR TITLE
feat: add restore command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ sudo schelk mount
 ./bench.sh
 # recovers it to the original state
 sudo schelk recover
+# or recover and immediately mount for the next run
+sudo schelk restore
 ```
 
 Note that both disks become untouchable. You must not mount them or 

--- a/ci/vm-init.sh
+++ b/ci/vm-init.sh
@@ -327,15 +327,50 @@ fi
 teardown /tmp/s4
 
 ###########################################################################
-# Story 5: Promote — make scratch the new baseline
+# Story 5: Restore — recover and mount for the next run
+#
+# From user-stories.md: restore is the one-command version of
+# recover-then-mount for tight benchmark iteration loops.
+###########################################################################
+story "STORY 5: Restore and remount for the next run"
+
+teardown /tmp/s5
+setup_volumes /tmp/s5
+
+assert_ok "init-new" schelk init-new \
+    --virgin "$VIRGIN" --scratch "$SCRATCH" --ramdisk "$RAMDISK" \
+    --mount-point "$MP" -y
+
+assert_ok "mount" schelk mount
+echo "restore workload" > "$MP/restore_workload.txt"
+dd if=/dev/urandom of="$MP/restore_writes.bin" bs=4k count=75 2>/dev/null
+sync
+
+assert_ok "restore" schelk restore
+is_mounted "$MP" || fail "restore remount" "not mounted after restore"
+
+if [ ! -f "$MP/restore_workload.txt" ] && [ ! -f "$MP/restore_writes.bin" ]; then
+    pass "restore recovered scratch"
+else
+    fail "restore recovery" "benchmark files survived restore"
+fi
+
+echo "next benchmark" > "$MP/next_run.txt"
+sync
+[ -f "$MP/next_run.txt" ] && \
+    pass "restore leaves volume ready for next run" || fail "restore next run" "write failed"
+teardown /tmp/s5
+
+###########################################################################
+# Story 6: Promote — make scratch the new baseline
 #
 # From SPEC.md promote: after a schema migration or data load, the user
 # wants the modified scratch to become the new virgin for future runs.
 ###########################################################################
-story "STORY 5: Promote (scratch becomes new virgin)"
+story "STORY 6: Promote (scratch becomes new virgin)"
 
-teardown /tmp/s5
-setup_volumes /tmp/s5
+teardown /tmp/s6
+setup_volumes /tmp/s6
 
 assert_ok "init-new" schelk init-new \
     --virgin "$VIRGIN" --scratch "$SCRATCH" --ramdisk "$RAMDISK" \
@@ -367,18 +402,18 @@ if [ -f "$MP/version.txt" ] && [ ! -f "$MP/bench_v2.txt" ]; then
 else
     fail "recover after promote" "bad file state"
 fi
-teardown /tmp/s5
+teardown /tmp/s6
 
 ###########################################################################
-# Story 6: Full recover — nuke and restore scratch from virgin
+# Story 7: Full recover — nuke and restore scratch from virgin
 #
 # From SPEC.md full-recover: costly full block copy, used when scratch is
 # corrupted or for initial setup. We verify the content is fully restored.
 ###########################################################################
-story "STORY 6: Full recover"
+story "STORY 7: Full recover"
 
-teardown /tmp/s6
-setup_volumes /tmp/s6
+teardown /tmp/s7
+setup_volumes /tmp/s7
 
 assert_ok "init-new" schelk init-new \
     --virgin "$VIRGIN" --scratch "$SCRATCH" --ramdisk "$RAMDISK" \
@@ -406,24 +441,24 @@ if [ "$content" = "baseline marker" ]; then
 else
     fail "full-recover content" "expected 'baseline marker', got '$content'"
 fi
-teardown /tmp/s6
+teardown /tmp/s7
 
 ###########################################################################
-# Story 7: Status reporting at every lifecycle point
+# Story 8: Status reporting at every lifecycle point
 #
 # From SPEC.md status: reports current state. We verify it correctly
 # reflects: uninitialized, initialized/idle, mounted/tracking, recovered.
 ###########################################################################
-story "STORY 7: Status at every lifecycle point"
+story "STORY 8: Status at every lifecycle point"
 
-teardown /tmp/s7
+teardown /tmp/s8
 rm -f /var/lib/schelk/state.json
 
 STATUS=$(schelk status 2>&1)
 echo "$STATUS" | grep -q "not initialized" && \
     pass "status: not initialized" || fail "status uninit" "wrong output"
 
-setup_volumes /tmp/s7
+setup_volumes /tmp/s8
 assert_ok "init-new" schelk init-new \
     --virgin "$VIRGIN" --scratch "$SCRATCH" --ramdisk "$RAMDISK" \
     --mount-point "$MP" -y
@@ -446,20 +481,20 @@ echo "$STATUS" | grep -q "Mounted: no (state)" && \
 echo "$STATUS" | grep -q "dm-era device: none" && \
     pass "status: after recover" || fail "status recovered" "wrong output"
 
-teardown /tmp/s7
+teardown /tmp/s8
 
 ###########################################################################
-# Story 8: Crash recovery — detect and handle inconsistent state
+# Story 9: Crash recovery — detect and handle inconsistent state
 #
 # From SPEC.md (mindset item 5): the app should prepare for crash of the
 # system or the app itself. We simulate a crash by leaving dm-era and the
 # mount live while tampering the state file to say "unmounted". Then we
 # verify that status detects the inconsistency and mount refuses.
 ###########################################################################
-story "STORY 8: Crash recovery (inconsistent state)"
+story "STORY 9: Crash recovery (inconsistent state)"
 
-teardown /tmp/s8
-setup_volumes /tmp/s8
+teardown /tmp/s9
+setup_volumes /tmp/s9
 
 assert_ok "init-new" schelk init-new \
     --virgin "$VIRGIN" --scratch "$SCRATCH" --ramdisk "$RAMDISK" \
@@ -495,19 +530,19 @@ assert_ok "full-recover after crash" schelk full-recover -y
 assert_ok "mount after crash cleanup" schelk mount
 is_mounted "$MP" || fail "mount after crash cleanup" "not mounted"
 
-teardown /tmp/s8
+teardown /tmp/s9
 
 ###########################################################################
-# Story 9: Reinitialize — init-new when already initialized
+# Story 10: Reinitialize — init-new when already initialized
 #
 # From SPEC.md init-new: "If the app state already exists, it offers if
 # it should reinitialize." Verify that re-running init-new with -y creates
 # a fresh filesystem and the full cycle still works.
 ###########################################################################
-story "STORY 9: Reinitialize"
+story "STORY 10: Reinitialize"
 
-teardown /tmp/s9
-setup_volumes /tmp/s9
+teardown /tmp/s10
+setup_volumes /tmp/s10
 
 assert_ok "first init-new" schelk init-new \
     --virgin "$VIRGIN" --scratch "$SCRATCH" --ramdisk "$RAMDISK" \
@@ -540,37 +575,37 @@ assert_ok "recover after reinit" schelk recover
 assert_ok "remount" schelk mount
 [ ! -f "$MP/reinit.txt" ] && \
     pass "full cycle works after reinit" || fail "cycle after reinit" "file survived"
-teardown /tmp/s9
+teardown /tmp/s10
 
 ###########################################################################
-# Story 10: Parallel instances — two independent schelk on separate volumes
+# Story 11: Parallel instances — two independent schelk on separate volumes
 #
 # From SPEC.md: "Override with --dm-era-name to run multiple schelk
 # instances in parallel (each must use a unique name, separate state files,
 # and separate volumes/ramdisks)."
 ###########################################################################
-story "STORY 10: Parallel instances"
+story "STORY 11: Parallel instances"
 
-teardown /tmp/s10a /tmp/s10b
+teardown /tmp/s11a /tmp/s11b
 
 # Instance A
-mkdir -p /tmp/s10a
-dd if=/dev/zero of=/tmp/s10a/virgin.img bs=1M count=32 2>/dev/null
-dd if=/dev/zero of=/tmp/s10a/scratch.img bs=1M count=32 2>/dev/null
-dd if=/dev/zero of=/tmp/s10a/ramdisk.img bs=1M count=4 2>/dev/null
-A_VIRGIN=$(/sbin/losetup --find --show /tmp/s10a/virgin.img)
-A_SCRATCH=$(/sbin/losetup --find --show /tmp/s10a/scratch.img)
-A_RAMDISK=$(/sbin/losetup --find --show /tmp/s10a/ramdisk.img)
+mkdir -p /tmp/s11a
+dd if=/dev/zero of=/tmp/s11a/virgin.img bs=1M count=32 2>/dev/null
+dd if=/dev/zero of=/tmp/s11a/scratch.img bs=1M count=32 2>/dev/null
+dd if=/dev/zero of=/tmp/s11a/ramdisk.img bs=1M count=4 2>/dev/null
+A_VIRGIN=$(/sbin/losetup --find --show /tmp/s11a/virgin.img)
+A_SCRATCH=$(/sbin/losetup --find --show /tmp/s11a/scratch.img)
+A_RAMDISK=$(/sbin/losetup --find --show /tmp/s11a/ramdisk.img)
 mkdir -p /tmp/mnt_a /tmp/state_a
 
 # Instance B
-mkdir -p /tmp/s10b
-dd if=/dev/zero of=/tmp/s10b/virgin.img bs=1M count=32 2>/dev/null
-dd if=/dev/zero of=/tmp/s10b/scratch.img bs=1M count=32 2>/dev/null
-dd if=/dev/zero of=/tmp/s10b/ramdisk.img bs=1M count=4 2>/dev/null
-B_VIRGIN=$(/sbin/losetup --find --show /tmp/s10b/virgin.img)
-B_SCRATCH=$(/sbin/losetup --find --show /tmp/s10b/scratch.img)
-B_RAMDISK=$(/sbin/losetup --find --show /tmp/s10b/ramdisk.img)
+mkdir -p /tmp/s11b
+dd if=/dev/zero of=/tmp/s11b/virgin.img bs=1M count=32 2>/dev/null
+dd if=/dev/zero of=/tmp/s11b/scratch.img bs=1M count=32 2>/dev/null
+dd if=/dev/zero of=/tmp/s11b/ramdisk.img bs=1M count=4 2>/dev/null
+B_VIRGIN=$(/sbin/losetup --find --show /tmp/s11b/virgin.img)
+B_SCRATCH=$(/sbin/losetup --find --show /tmp/s11b/scratch.img)
+B_RAMDISK=$(/sbin/losetup --find --show /tmp/s11b/ramdisk.img)
 mkdir -p /tmp/mnt_b /tmp/state_b
 
 assert_ok "init instance A" schelk init-new \
@@ -610,19 +645,19 @@ fi
 # Cleanup
 schelk recover --state-path /tmp/state_a/state.json -y 2>&1 >/dev/null
 schelk recover --state-path /tmp/state_b/state.json 2>&1 >/dev/null
-teardown /tmp/s10a /tmp/s10b
+teardown /tmp/s11a /tmp/s11b
 
 ###########################################################################
-# Story 11: Full recover with stale mounted state (simulated reboot)
+# Story 12: Full recover with stale mounted state (simulated reboot)
 #
 # After a reboot the state file still says "mounted" but the dm-era
 # device and filesystem mount are gone.  full-recover should detect this
 # stale state, auto-clear it, and proceed with the copy.
 ###########################################################################
-story "STORY 11: Full recover with stale mounted state (simulated reboot)"
+story "STORY 12: Full recover with stale mounted state (simulated reboot)"
 
-teardown /tmp/s11
-setup_volumes /tmp/s11
+teardown /tmp/s12
+setup_volumes /tmp/s12
 
 assert_ok "init-new" schelk init-new \
     --virgin "$VIRGIN" --scratch "$SCRATCH" --ramdisk "$RAMDISK" \
@@ -662,21 +697,21 @@ assert_fail "full-recover rejects when dm-era still exists" schelk full-recover 
 
 # Clean up the live dm-era device
 dmsetup remove bench_era 2>/dev/null
-teardown /tmp/s11
+teardown /tmp/s12
 
 ###########################################################################
-# Story 12: Recover is a no-op when not mounted
+# Story 13: Recover is a no-op when not mounted
 #
-# From user-stories.md story 18: recover should exit 0 when the volume
+# From user-stories.md: recover should exit 0 when the volume
 # is not mounted.  This matters for CI scripts that run
 # `schelk recover || schelk full-recover` — a non-zero exit from
 # recover when nothing is mounted would trigger an unnecessary
 # full-recover.
 ###########################################################################
-story "STORY 12: Recover is a no-op when not mounted"
+story "STORY 13: Recover is a no-op when not mounted"
 
-teardown /tmp/s12
-setup_volumes /tmp/s12
+teardown /tmp/s13
+setup_volumes /tmp/s13
 
 assert_ok "init-new" schelk init-new \
     --virgin "$VIRGIN" --scratch "$SCRATCH" --ramdisk "$RAMDISK" \
@@ -692,22 +727,22 @@ sync
 assert_ok "recover (normal)" schelk recover
 assert_ok "recover again (already recovered)" schelk recover
 
-teardown /tmp/s12
+teardown /tmp/s13
 
 ###########################################################################
-# Story 13: O_EXCL refuses to write to a volume mounted outside schelk
+# Story 14: O_EXCL refuses to write to a volume mounted outside schelk
 #
-# From user-stories.md story 20 and SPEC.md principles 3 and 11
+# From user-stories.md and SPEC.md principles 3 and 11
 # ("foolproof", "principle of least surprise"). If the user mounts virgin
 # or scratch outside of schelk, any subsequent destructive write would
 # silently corrupt the live filesystem. Opening the raw device with
 # O_EXCL lets the kernel reject the operation with EBUSY before any
 # block is written.
 ###########################################################################
-story "STORY 13: Refuse writes to volumes mounted outside schelk"
+story "STORY 14: Refuse writes to volumes mounted outside schelk"
 
-teardown /tmp/s13
-setup_volumes /tmp/s13
+teardown /tmp/s14
+setup_volumes /tmp/s14
 
 assert_ok "init-new" schelk init-new \
     --virgin "$VIRGIN" --scratch "$SCRATCH" --ramdisk "$RAMDISK" \
@@ -715,8 +750,8 @@ assert_ok "init-new" schelk init-new \
 
 # Mount scratch directly, outside schelk's control. After init-new the
 # scratch volume is byte-identical to virgin and carries a valid ext4 fs.
-mkdir -p /tmp/s13_external
-mount -t ext4 "$SCRATCH" /tmp/s13_external
+mkdir -p /tmp/s14_external
+mount -t ext4 "$SCRATCH" /tmp/s14_external
 
 # full-recover writes to scratch. With O_EXCL on the destination open,
 # the kernel must reject it because scratch is currently mounted.
@@ -729,13 +764,13 @@ echo "$LAST_OUT" | grep -qi "in use" && \
     fail "error message" "did not mention 'in use'"
 
 # Unmounting the external mount must let full-recover succeed.
-umount /tmp/s13_external
+umount /tmp/s14_external
 
 assert_ok "full-recover succeeds after external unmount" \
     schelk full-recover -y
 
-umount /tmp/s13_external 2>/dev/null || true
-teardown /tmp/s13 /tmp/s13_external
+umount /tmp/s14_external 2>/dev/null || true
+teardown /tmp/s14 /tmp/s14_external
 
 ###########################################################################
 # Results

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -9,8 +9,9 @@ Read the README.md and other documents. This is linux only.
 3. full-recover
 4. mount
 5. recover
-6. promote
-7. status
+6. restore
+7. promote
+8. status
 
 ### `init-new`
 
@@ -156,6 +157,15 @@ And then perform copy of the blocks from the virgin to scratch according to `cha
 progress of copying must be displayed. After finish, it should print a report.
 
 Once it succeeded we should update the app state and remove `changed.xml`.
+
+### `restore`
+
+Convenience command for the common benchmark iteration loop. It performs `recover` and, if recovery
+succeeds, immediately performs `mount`.
+
+Pre-checks and behavior are the same as `recover` followed by `mount`. It accepts the same `--kill`
+flag as `recover` for killing processes that block the unmount. If recovery fails, it must not try
+to mount.
 
 ### `promote`
 

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -48,7 +48,8 @@ builds) and confirm that each recovery is fast and the volume state is identical
 
 Steps:
 1. `schelk mount` → run benchmark → `schelk recover`. Note recovery duration and report.
-2. `schelk mount` → run same benchmark → `schelk recover`. Note recovery duration and report.
+2. `schelk mount` → run same benchmark → `schelk restore`. Note recovery duration and report,
+   and verify the volume is mounted for the next run.
 3. Verify recovery times are consistent and results are reproducible.
 
 ## 5. Promote after a schema migration

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -48,11 +48,22 @@ builds) and confirm that each recovery is fast and the volume state is identical
 
 Steps:
 1. `schelk mount` → run benchmark → `schelk recover`. Note recovery duration and report.
-2. `schelk mount` → run same benchmark → `schelk restore`. Note recovery duration and report,
-   and verify the volume is mounted for the next run.
+2. `schelk mount` → run same benchmark → `schelk recover`. Note recovery duration and report.
 3. Verify recovery times are consistent and results are reproducible.
 
-## 5. Promote after a schema migration
+## 5. Restore and remount for the next run
+
+As a benchmarker, I want a single command that restores the scratch volume and mounts it again,
+so I can move directly from one completed benchmark run to the next.
+
+Steps:
+1. `schelk mount`
+2. Run the SUT against `/schelk`.
+3. `schelk restore`
+4. Verify the scratch volume is restored to baseline and mounted again.
+5. Run the next benchmark without a separate `schelk mount`.
+
+## 6. Promote after a schema migration
 
 As a benchmarker, I ran a SUT version that performs a database migration. I want to promote
 the migrated scratch volume to become the new virgin so future benchmarks start from the
@@ -64,7 +75,7 @@ Steps:
 3. `schelk promote`
 4. `schelk mount` → verify the SUT starts without re-migrating.
 
-## 6. Recover after a process crash
+## 7. Recover after a process crash
 
 As a benchmarker, the SUT crashed mid-benchmark (e.g., kill -9) but the host stayed up. I want
 schelk to handle this gracefully and let me recover without a full copy.
@@ -74,7 +85,7 @@ Steps:
 2. `schelk recover` — should detect dirty state and recover incrementally.
 3. Verify the volume is restored and the SUT starts cleanly.
 
-## 7. Detect unsafe state after host reboot
+## 8. Detect unsafe state after host reboot
 
 As a benchmarker, the host rebooted or lost power while schelk was mounted. Since dm-era
 metadata lives on a ramdisk, incremental recovery is not possible. I want schelk to detect
@@ -87,7 +98,7 @@ Steps:
    are gone, auto-clears the stale flag, and restores scratch from virgin.
 4. Verify the SUT starts cleanly.
 
-## 8. Full recovery fallback
+## 9. Full recovery fallback
 
 As a benchmarker, when incremental recovery is unsafe (e.g., after host reboot, tampering, or
 a bad `--no-copy` assumption), I want to run `full-recover` to restore scratch from virgin.
@@ -97,7 +108,7 @@ Steps:
 2. Wait for the full copy to complete.
 3. `schelk mount` → verify the SUT starts cleanly from the baseline.
 
-## 9. Detect virgin volume tampering
+## 10. Detect virgin volume tampering
 
 As a benchmarker, I accidentally mounted the virgin volume outside of schelk. I want schelk to
 detect this and refuse to proceed before I run a benchmark with a corrupted baseline.
@@ -107,7 +118,7 @@ Steps:
 2. Unmount it.
 3. `schelk mount` — should detect superblock hash mismatch and refuse to proceed.
 
-## 10. Prevent double mount
+## 11. Prevent double mount
 
 As a benchmarker, I accidentally run `schelk mount` twice. I want schelk to detect the existing
 mount and refuse rather than corrupting state.
@@ -116,7 +127,7 @@ Steps:
 1. `schelk mount`
 2. `schelk mount` again — should fail with a clear error.
 
-## 11. Init-from with --no-copy
+## 12. Init-from with --no-copy
 
 As a benchmarker, I prepared both volumes identically myself (e.g., via dd). I want to skip the
 full copy during init to save time.
@@ -127,7 +138,7 @@ Steps:
 3. `schelk mount` → run benchmark → `schelk recover`.
 4. Verify recovery produces correct results.
 
-## 12. Environment validation on init
+## 13. Environment validation on init
 
 As a benchmarker on a fresh machine, I want schelk to tell me exactly what's missing before I
 waste time on a partial setup.
@@ -137,7 +148,7 @@ Steps:
 2. `schelk init-new` — should fail with a clear message about the missing tool.
 3. Install it, retry — should succeed.
 
-## 13. Environment validation on recover
+## 14. Environment validation on recover
 
 As a benchmarker, I want schelk to check that recovery tools are available before attempting
 recovery.
@@ -147,7 +158,7 @@ Steps:
 2. `schelk recover` — should fail with a clear message about the missing tool.
 3. Install it, retry — should succeed.
 
-## 14. Destructive confirmation prompts
+## 15. Destructive confirmation prompts
 
 As a user, I want destructive commands (`init-new`, `init-from`, `full-recover`, `promote`) to
 prompt for confirmation by default and proceed non-interactively only with `-y`.
@@ -157,7 +168,7 @@ Steps:
 2. Decline — should abort without changes.
 3. Run `schelk init-new ... -y` — should proceed without prompting.
 
-## 15. Reinitialization when state already exists
+## 16. Reinitialization when state already exists
 
 As a user, if schelk is already initialized, I want a second `init-*` call to prompt for
 reinitialization rather than silently overwriting state.
@@ -167,7 +178,7 @@ Steps:
 2. `schelk init-new ...` again — should warn that state already exists and prompt to reinitialize.
 3. Decline — state should remain unchanged.
 
-## 16. Check status
+## 17. Check status
 
 As a benchmarker, I want `schelk status` to tell me whether schelk is initialized, mounted,
 and safe to recover or promote.
@@ -178,7 +189,7 @@ Steps:
 3. After mount — should report initialized and mounted.
 4. After recover — should report initialized, not mounted.
 
-## 17. Cleanup after recover and promote
+## 18. Cleanup after recover and promote
 
 As a benchmarker, after `recover` or `promote`, I want schelk to leave no active dm-era device
 or temporary state behind.
@@ -188,7 +199,7 @@ Steps:
 2. Verify no dm-era device exists (`dmsetup ls` should not show `bench_era`).
 3. Verify no leftover `changed.xml` or temp files.
 
-## 18. Recover is a no-op when not mounted
+## 19. Recover is a no-op when not mounted
 
 As a CI pipeline author, I want `schelk recover` to succeed (exit 0) when the volume is not
 mounted, so that unconditional cleanup like `schelk recover || schelk full-recover` does not
@@ -200,7 +211,7 @@ Steps:
 3. `schelk mount` → `schelk recover` — normal recovery, also exit 0.
 4. `schelk recover` again — already recovered, should exit 0.
 
-## 19. Transparent action logging
+## 20. Transparent action logging
 
 As a benchmarker, I want every action schelk takes to be printed to the screen so I can
 understand what happened and diagnose issues.
@@ -210,7 +221,7 @@ Steps:
 2. Run `schelk mount` — should print dm-era setup and mount actions.
 3. Run `schelk recover` — should print unmount, era snapshot, block copy progress, and cleanup.
 
-## 20. Refuse to write to a volume mounted outside schelk
+## 21. Refuse to write to a volume mounted outside schelk
 
 As a benchmarker, I sometimes mount virgin or scratch outside of schelk by mistake (e.g.,
 running `mount` for a quick inspection and forgetting to unmount). If I then run a destructive

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 // CLI definition using clap
-// Defines subcommands: init-new, init-from, full-recover, mount, recover, status
+// Defines subcommands: init-new, init-from, full-recover, mount, recover, restore, promote, status
 // Global flags: -y (skip confirmation)
 //
 // Default behavior: If no subcommand is provided, runs 'status'
@@ -120,6 +120,13 @@ pub enum Command {
 
     /// Recover scratch volume from virgin (surgical restore)
     Recover {
+        /// Kill processes blocking unmount instead of failing
+        #[arg(short = 'k', long = "kill")]
+        kill: bool,
+    },
+
+    /// Recover scratch volume from virgin, then mount it again
+    Restore {
         /// Kill processes blocking unmount instead of failing
         #[arg(short = 'k', long = "kill")]
         kill: bool,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,4 +7,5 @@ pub mod init_new;
 pub mod mount;
 pub mod promote;
 pub mod recover;
+pub mod restore;
 pub mod status;

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -28,6 +28,11 @@ pub async fn run() -> Result<()> {
 
     let _lock = state::lock()?;
 
+    run_locked().await
+}
+
+/// Run the mount command while the caller holds the schelk state lock.
+pub(crate) async fn run_locked() -> Result<()> {
     let app_state = state::load()?.ok_or_else(not_initialized)?;
 
     if app_state.is_mounted {

--- a/src/commands/recover.rs
+++ b/src/commands/recover.rs
@@ -34,6 +34,11 @@ pub async fn run(kill: bool) -> Result<()> {
 
     let _lock = state::lock()?;
 
+    run_locked(kill).await
+}
+
+/// Run the recover command while the caller holds the schelk state lock.
+pub(crate) async fn run_locked(kill: bool) -> Result<()> {
     let app_state = state::load()?.ok_or_else(not_initialized)?;
 
     if !app_state.is_mounted {

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -1,0 +1,37 @@
+// Command: restore
+// Recovers scratch volume from virgin, then mounts it again for the next run.
+//
+// This is a convenience command for the common benchmark loop:
+//   schelk recover && schelk mount
+
+use eyre::{Result, WrapErr};
+
+use crate::commands::{mount, recover};
+use crate::{env, state};
+
+/// Run the restore command.
+///
+/// If `kill` is true, processes blocking the recovery unmount are sent
+/// SIGKILL and the unmount is retried.
+pub async fn run(kill: bool) -> Result<()> {
+    env::require_root()?;
+
+    let _lock = state::lock()?;
+
+    println!("Restoring scratch volume from virgin, then remounting it.");
+    println!();
+
+    recover::run_locked(kill)
+        .await
+        .wrap_err("Restore failed during recovery")?;
+
+    println!();
+    println!("Recovery succeeded. Mounting restored scratch volume...");
+    println!();
+
+    mount::run_locked()
+        .await
+        .wrap_err("Restore recovered the scratch volume but failed to mount it")?;
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use cli::{Cli, Command};
 
 /// Install signal handlers that ignore SIGINT and SIGTERM, printing a warning instead.
 ///
-/// Commands like `recover`, `mount`, `promote`, and `full-recover` manipulate dm-era devices
+/// Commands like `recover`, `restore`, `mount`, `promote`, and `full-recover` manipulate dm-era devices
 /// and block volumes in multi-step sequences. Interrupting them mid-way can leave volumes in
 /// an inconsistent state that requires a costly full recovery. We catch these signals and
 /// refuse to act on them, letting the operation complete naturally.
@@ -125,6 +125,10 @@ async fn main() -> eyre::Result<()> {
         Some(Command::Recover { kill }) => {
             ignore_termination_signals();
             commands::recover::run(kill).await
+        }
+        Some(Command::Restore { kill }) => {
+            ignore_termination_signals();
+            commands::restore::run(kill).await
         }
         Some(Command::Promote { kill }) => {
             ignore_termination_signals();


### PR DESCRIPTION
## Summary
- add `schelk restore` as a first-class command that runs `recover` and then remounts the scratch volume
- preserve the state lock across the recover/remount sequence so the operation stays atomic from schelk's perspective
- update CLI dispatch and docs to reflect the new workflow

## Testing
- Not run (not requested)