### PR TITLE
perf: reset brd ramdisks with blkdiscard

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ cargo install --path .
 sudo modprobe brd rd_size=4194304
 ```
 
+When the configured metadata device is a whole brd device such as `/dev/ram0`, `schelk mount`
+resets it with `blkdiscard` when available. That drops brd's backing pages instead of writing
+zeroes through the entire ramdisk, with a zero-write fallback for devices that do not support this.
+
 ### Initialize
 
 There are two initialization paths:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -110,8 +110,10 @@ Checks:
 1. Spot checks state of volumes and verifies that it is the same as the expected per the state of the 
 app.
 
-Zeroes the ramdisk and initializes dm-era for the scratch volume using the configured device name
-(stored in state as `dm_era_name`, defaults to `bench_era`).
+Resets the ramdisk metadata device and initializes dm-era for the scratch volume using the
+configured device name (stored in state as `dm_era_name`, defaults to `bench_era`). For whole Linux
+brd devices such as `/dev/ram0`, reset may use `blkdiscard` because discarded brd pages read back as
+zeroes; other devices fall back to writing zeroes across the metadata device.
 
 ```
 dmsetup create <dm_era_name> ... era /dev/ram0 /dev/nvme_ <granularity>

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -8,7 +8,7 @@
 //   4. Must not already be mounted (fool-proof check)
 //
 // Operation:
-//   1. Zero the RAM disk
+//   1. Reset the RAM disk metadata device
 //   2. Create dm-era device: dmsetup create <dm_era_name> ... era /dev/ram0 /dev/scratch <granularity>
 //   3. Mount the dm-era device at the configured mount point
 //   4. Update app state to mark as mounted
@@ -84,12 +84,10 @@ pub(crate) async fn run_locked() -> Result<()> {
         ));
     }
 
-    // Step 3: Zero the RAM disk.
-    //
-    // I am not entirely sure if this is strictly necessary but ChatGPT was suggesting that and
-    // we'll err on the safe side here.
-    println!("Zeroing RAM disk...");
-    io::zero(&app_state.ramdisk)?;
+    // Step 3: Reset the RAM disk metadata device.
+    println!("Resetting RAM disk metadata...");
+    let reset_method = io::reset_to_zero(&app_state.ramdisk)?;
+    println!("RAM disk reset using {}.", reset_method.description());
 
     // Step 4: Create dm-era device
     println!("Creating dm-era device '{}'...", app_state.dm_era_name);

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,19 +1,25 @@
 // Low-level I/O operations for block devices
-// Handles reading, writing, copying, and zeroing of block devices
+// Handles reading, writing, copying, and resetting block devices
 
 mod uring;
 
-use std::fs::{File, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::path::Path;
+use std::process::{Command, Stdio};
 
 use eyre::{Result, WrapErr, eyre};
+use nix::sys::stat::{major, minor};
 
 /// Size of superblock to read for hashing (4KB)
 const SUPERBLOCK_SIZE: usize = 4096;
 
 /// Buffer size for zeroing (1MB)
 const BUFFER_SIZE: usize = 1024 * 1024;
+
+/// Linux block major for brd-backed `/dev/ramN` devices.
+const RAMDISK_MAJOR: u64 = 1;
 
 /// A range of blocks to copy
 #[derive(Debug, Clone)]
@@ -53,6 +59,40 @@ pub fn read_superblock(path: &Path) -> Result<Vec<u8>> {
     Ok(buf)
 }
 
+/// Method used to reset a device back to zeroes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResetMethod {
+    /// Device was discarded with `blkdiscard`.
+    Blkdiscard,
+    /// Device was overwritten with zeroes.
+    ZeroWrite,
+}
+
+impl ResetMethod {
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::Blkdiscard => "blkdiscard",
+            Self::ZeroWrite => "sequential zero write",
+        }
+    }
+}
+
+/// Reset the dm-era metadata device to all zeroes.
+///
+/// For Linux brd devices (`/dev/ramN`), discard frees the backing pages and reads from missing
+/// pages return zeroes. That makes resetting large ramdisks much cheaper than writing zeroes
+/// through the entire device. Other devices keep the conservative zero-write behavior because
+/// discard does not universally guarantee zero-filled reads.
+pub fn reset_to_zero(path: &Path) -> Result<ResetMethod> {
+    if can_reset_brd_with_blkdiscard(path)? {
+        blkdiscard(path)?;
+        return Ok(ResetMethod::Blkdiscard);
+    }
+
+    zero(path)?;
+    Ok(ResetMethod::ZeroWrite)
+}
+
 /// Zero the entire block device.
 pub fn zero(path: &Path) -> Result<()> {
     let size = get_size(path)?;
@@ -73,6 +113,98 @@ pub fn zero(path: &Path) -> Result<()> {
     }
 
     file.sync_all().wrap_err("Failed to sync device")?;
+
+    Ok(())
+}
+
+fn can_reset_brd_with_blkdiscard(path: &Path) -> Result<bool> {
+    let Some(sysfs_path) = brd_sysfs_path(path)? else {
+        return Ok(false);
+    };
+
+    if !blkdiscard_available() {
+        return Ok(false);
+    }
+
+    let discard_max_bytes = read_sysfs_u64(&sysfs_path.join("queue/discard_max_bytes"))?;
+    if discard_max_bytes == 0 {
+        return Ok(false);
+    }
+
+    let discard_granularity = read_sysfs_u64(&sysfs_path.join("queue/discard_granularity"))?;
+    let size = get_size(path)?;
+    if discard_granularity == 0 || size % discard_granularity != 0 {
+        return Ok(false);
+    }
+
+    Ok(true)
+}
+
+fn blkdiscard_available() -> bool {
+    Command::new("blkdiscard")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok()
+}
+
+fn brd_sysfs_path(path: &Path) -> Result<Option<std::path::PathBuf>> {
+    let metadata =
+        fs::metadata(path).wrap_err_with(|| format!("Cannot stat {}", path.display()))?;
+    if !metadata.file_type().is_block_device() {
+        return Ok(None);
+    }
+
+    let major = major(metadata.rdev());
+    if major != RAMDISK_MAJOR {
+        return Ok(None);
+    }
+
+    let sysfs_path = fs::canonicalize(format!(
+        "/sys/dev/block/{}:{}",
+        major,
+        minor(metadata.rdev())
+    ))
+    .wrap_err_with(|| format!("Cannot inspect sysfs metadata for {}", path.display()))?;
+
+    let Some(name) = sysfs_path.file_name().and_then(|name| name.to_str()) else {
+        return Ok(None);
+    };
+
+    Ok(is_whole_brd_device_name(name).then_some(sysfs_path))
+}
+
+fn is_whole_brd_device_name(name: &str) -> bool {
+    name.strip_prefix("ram")
+        .is_some_and(|suffix| !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit()))
+}
+
+fn read_sysfs_u64(path: &Path) -> Result<u64> {
+    fs::read_to_string(path)
+        .wrap_err_with(|| format!("Cannot read {}", path.display()))?
+        .trim()
+        .parse::<u64>()
+        .wrap_err_with(|| format!("Cannot parse {}", path.display()))
+}
+
+fn blkdiscard(path: &Path) -> Result<()> {
+    let output = Command::new("blkdiscard")
+        .arg(path)
+        .output()
+        .wrap_err("Failed to execute blkdiscard")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let msg = stderr.trim();
+        if msg.is_empty() {
+            return Err(eyre!(
+                "blkdiscard failed with exit code {:?}",
+                output.status.code()
+            ));
+        }
+        return Err(eyre!("blkdiscard failed: {}", msg));
+    }
 
     Ok(())
 }
@@ -99,4 +231,42 @@ where
     F: FnMut(u64, u64),
 {
     uring::copy_blocks(src, dst, blocks, granularity, progress)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Seek, SeekFrom, Write};
+    use std::os::fd::AsRawFd;
+
+    use super::{ResetMethod, is_whole_brd_device_name, reset_to_zero};
+
+    #[test]
+    fn brd_name_detection_accepts_whole_ramdisks() {
+        assert!(is_whole_brd_device_name("ram0"));
+        assert!(is_whole_brd_device_name("ram12"));
+    }
+
+    #[test]
+    fn brd_name_detection_rejects_other_devices_and_partitions() {
+        assert!(!is_whole_brd_device_name("ram"));
+        assert!(!is_whole_brd_device_name("ram0p1"));
+        assert!(!is_whole_brd_device_name("loop0"));
+        assert!(!is_whole_brd_device_name("nvme0n1"));
+    }
+
+    #[test]
+    fn reset_to_zero_falls_back_to_zero_write_for_regular_files() {
+        let mut file = tempfile::tempfile().unwrap();
+        file.write_all(&[0xff; 8192]).unwrap();
+        file.flush().unwrap();
+
+        let path = format!("/proc/self/fd/{}", file.as_raw_fd());
+        let method = reset_to_zero(std::path::Path::new(&path)).unwrap();
+        assert_eq!(method, ResetMethod::ZeroWrite);
+
+        file.seek(SeekFrom::Start(0)).unwrap();
+        let mut contents = Vec::new();
+        file.read_to_end(&mut contents).unwrap();
+        assert!(contents.iter().all(|byte| *byte == 0));
+    }
 }


### PR DESCRIPTION
Uses `blkdiscard` to reset dm-era metadata when the configured ramdisk is a whole Linux brd device such as `/dev/ram0`.

The brd driver handles discard by dropping backing pages, and missing pages read back as zeroes, so this avoids writing zeroes across multi-GiB metadata devices during `schelk mount`. The optimization is deliberately limited to whole `ramN` block devices with discard support and aligned size; loop-backed metadata devices and anything else keep the existing sequential zero-write fallback.

The mount command now reports which reset method was used, and the README/spec document the brd behavior and fallback.

Validated with `cargo fmt --check` and `cargo test`.